### PR TITLE
Align meetup domain language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,260 @@
+# Austin AI Club Meetup List
+
+This context describes the language for curating Austin AI Club meetups, topic boards, reminders, and the durable public archive.
+
+## Language
+
+**Austin AI Club**:
+The community gathering this website archives and supports.
+
+**Member**:
+A person in or near the Austin AI Club community.
+
+**Meetup**:
+A dated Austin AI Club gathering with a topic board, optional reminder metadata, and an archive page.
+_Avoid_: Session
+
+**Meetup Slot**:
+A tentative calendar placeholder for a likely Austin AI Club gathering.
+_Avoid_: Meetup
+
+**Event Metadata**:
+The time, location, calendar, and reminder details for a Meetup.
+
+**Topic Board**:
+The curated set of Tracks, Topics, Community Slot, and Showcases for a Meetup.
+
+**Track**:
+A stable high-level discussion category used to group meetup topics.
+_Avoid_: Section, bucket
+
+**Topic**:
+A single discussion item on a meetup board, backed by one or more Links.
+_Avoid_: Story, item, link
+
+**Discussion Fit**:
+The editorial standard for whether an AI item belongs on the meetup board.
+_Avoid_: Interestingness
+
+**Major AI Story**:
+An AI story with enough industry or cultural gravity that Austin AI Club would naturally discuss it.
+
+**Open Source Lens**:
+An editorial lens for favoring topics with inspectable code, open weights, reproducible artifacts, or open ecosystem impact.
+_Avoid_: Track
+
+**Privacy Lens**:
+An editorial lens for favoring topics that affect user data control, local-first workflows, surveillance risk, or privacy-preserving AI systems.
+_Avoid_: Track
+
+**Security Lens**:
+An editorial lens for evaluating how topics affect attack surfaces, misuse paths, defensive practice, operational risk, or trust boundaries.
+
+**Link**:
+A source URL that supports a Topic or is submitted for possible curation into a Topic.
+_Avoid_: Topic
+
+**Submission**:
+An incoming Link or Showcase contribution that is immediately associated with a target Meetup.
+_Avoid_: Suggestion, proposal
+
+**Curation**:
+The organizer workflow of choosing, grouping, wording, and placing material on a Meetup board.
+
+**Markdown Archive**:
+The durable source of record for authored Meetup notes.
+_Avoid_: Data source
+
+**Meetup Data**:
+The structured rendering model for a whole Meetup, curated from the Markdown Archive for the website and Presentation Mode.
+_Avoid_: Archive of record
+
+**Presentation Mode**:
+A public slide-by-slide surface for presenting Meetup Data during or after a Meetup.
+
+**Reminder**:
+A subscriber email sent for an actual planned Meetup.
+_Avoid_: Meetup Slot reminder
+
+**Presenter Notes**:
+Public host-facing notes that add extra context for presenting a Topic or Showcase.
+_Avoid_: Private notes
+
+**Community Slot**:
+The end-of-meetup area reserved for short member-led shares.
+_Avoid_: Track
+
+**Showcase**:
+A short member-led share proposed for the Community Slot.
+_Avoid_: Talk, presentation
+
+**Local Builds & Projects**:
+The track for Austin/member/community-orbit projects, demos, prototypes, launches, and things people can run or inspect directly.
+_Avoid_: SHIPPED
+
+**Agent Infrastructure**:
+The track for agent runtimes, protocols, interfaces, orchestration layers, tool-calling systems, and deployment plumbing.
+
+**Models & Research**:
+The track for model releases, benchmark shifts, papers, architecture updates, and capability comparisons.
+
+**Security**:
+The track for attacks, abuse patterns, red-team findings, prompt injection, defensive work, and security-relevant failures.
+
+**Big Tech Moves**:
+The track for major company moves, hardware launches, ecosystem shifts, acquisitions, platform bets, product strategy, and policy or infrastructure changes that shape AI development.
+
+## Relationships
+
+- A **Meetup** has one **Topic Board**.
+- A **Topic Board** has zero or more **Tracks**.
+- A **Topic Board** has one **Community Slot**.
+- The **Community Slot** appears after all **Tracks**.
+- A **Meetup** can have optional **Event Metadata**.
+- **Austin AI Club** has recurring **Meetups**.
+- **Austin AI Club** tries to meet biweekly.
+- **Meetup Slots** follow the biweekly planning cadence by default.
+- A **Meetup Slot** can have template **Event Metadata** for calendar display.
+- A **Meetup Slot** does not have a **Topic Board**.
+- A **Meetup Slot** can be replaced by a hand-authored **Meetup**.
+- A **Meetup** is recorded in the **Markdown Archive**.
+- **Meetup Data** is curated from the **Markdown Archive**.
+- **Presentation Mode** renders **Meetup Data**.
+- A **Track** has zero or more **Topics**.
+- A **Topic** belongs to exactly one **Track**.
+- A **Topic** has one or more **Links**.
+- A **Topic** can have **Presenter Notes**.
+- A **Topic** must have **Discussion Fit** for Austin AI Club.
+- A **Major AI Story** has **Discussion Fit** even when its builder angle is not yet obvious.
+- The **Open Source Lens** shapes **Discussion Fit** but is not a **Track**.
+- The **Privacy Lens** shapes **Discussion Fit** but is not a **Track**.
+- The **Security Lens** shapes **Discussion Fit** across **Tracks**.
+- **Security** is both a standard **Track** and a **Security Lens**.
+- A **Showcase** can have **Presenter Notes**.
+- A **Submission** belongs to exactly one target **Meetup**.
+- A new **Submission** always targets the next upcoming **Meetup** or **Meetup Slot**.
+- A **Submission** requires a title.
+- A **Submission** can become a **Topic** or **Showcase** through **Curation**.
+- **Curation** can rewrite, combine, reframe, order, or move submitted material.
+- **Curation** orders **Tracks** and **Topics** by intended discussion flow.
+- **Curation** orders **Showcases** by organizer or in-room choice.
+- **Reminders** are sent only for actual planned **Meetups**, not tentative **Meetup Slots**.
+- A **Topic Board** has one **Community Slot** after its standard **Tracks**.
+- A **Community Slot** has zero or more **Showcases**.
+- An empty **Community Slot** appears only for the next upcoming **Meetup**.
+- An empty **Community Slot** is omitted from past **Meetups**.
+- A **Showcase** can have zero or more **Links**.
+- **Local Builds & Projects**, **Agent Infrastructure**, **Models & Research**, **Security**, and **Big Tech Moves** are the standard recurring **Tracks**.
+- Standard **Tracks** use their standard order by default: **Local Builds & Projects**, **Agent Infrastructure**, **Models & Research**, **Security**, **Big Tech Moves**.
+- Empty standard **Tracks** are omitted from an authored **Meetup**.
+
+## Example dialogue
+
+> **Dev:** "A member launched a small Codex workflow this week. Should that go in SHIPPED?"
+> **Domain expert:** "No — put it in **Local Builds & Projects** and say in the **Topic** description that it shipped."
+>
+> **Dev:** "A non-local open-source repo is runnable and interesting. Does it go in **Local Builds & Projects**?"
+> **Domain expert:** "No — use **Local Builds & Projects** for Austin/member/community-orbit work, and place outside projects by their main discussion angle."
+>
+> **Dev:** "The calendar shows a generated date two weeks out. Is that already a **Meetup**?"
+> **Domain expert:** "No — that is a **Meetup Slot** until we hand-author the board. We try to stay biweekly, but can override slots when the real date shifts."
+>
+> **Dev:** "If a generated **Meetup Slot** has time and location details, is it confirmed?"
+> **Domain expert:** "No — **Meetup Slots** can use template **Event Metadata** for calendar display without becoming planned **Meetups**."
+>
+> **Dev:** "Can a **Meetup Slot** have a **Topic Board**?"
+> **Domain expert:** "No — once there is a **Topic Board**, it is a **Meetup**, not just a **Meetup Slot**."
+>
+> **Dev:** "Is a board without time and location metadata still a **Meetup**?"
+> **Domain expert:** "Yes — **Event Metadata** is optional. A **Meetup** can still exist as an archived topic board."
+>
+> **Dev:** "Is the **Meetup** the same thing as the board?"
+> **Domain expert:** "No — the **Meetup** is the gathering, and the **Topic Board** is the curated artifact for that gathering."
+>
+> **Dev:** "The Markdown notes and structured data disagree. Which one should I trust?"
+> **Domain expert:** "Trust the **Markdown Archive** as the durable record, then update the **Meetup Data** to render the intended board."
+>
+> **Dev:** "Are **Presenter Notes** private?"
+> **Domain expert:** "No — they are public notes to self that add context for presenting a **Topic** or **Showcase**."
+>
+> **Dev:** "Should the member demo at the end be another **Track**?"
+> **Domain expert:** "No — that belongs in the **Community Slot** as a **Showcase** after the **Tracks**."
+>
+> **Dev:** "Should we show an empty **Security** track when there are no security topics this week?"
+> **Domain expert:** "No — omit empty standard **Tracks** from the authored **Meetup**."
+>
+> **Dev:** "Should a past **Meetup** show an empty **Community Slot**?"
+> **Domain expert:** "No — only the next upcoming **Meetup** should show an empty **Community Slot** as an open-slot call to action."
+>
+> **Dev:** "Does any interesting AI news qualify as a **Topic**?"
+> **Domain expert:** "No — a **Topic** should either be an unavoidable major AI story or something important to developers and builders who care about cutting-edge capability, security, privacy, and open source."
+>
+> **Dev:** "Does a huge AI story need an immediate builder takeaway to belong?"
+> **Domain expert:** "No — a **Major AI Story** has **Discussion Fit** because the room will naturally need to talk about it."
+>
+> **Dev:** "Should open-source items have their own **Track**?"
+> **Domain expert:** "No — use the **Open Source Lens** when deciding what belongs, then place the **Topic** in the best existing **Track**."
+>
+> **Dev:** "Should privacy have its own **Track**?"
+> **Domain expert:** "No — use the **Privacy Lens** when deciding what belongs, then place the **Topic** by its discussion angle."
+>
+> **Dev:** "If a model release has security implications, does it automatically move to the **Security** track?"
+> **Domain expert:** "No — **Security** is also a **Security Lens**. Put the **Topic** in **Models & Research** if that is the main discussion angle."
+>
+> **Dev:** "Does an energy, regulation, or export-control story belong if no major AI company shipped something?"
+> **Domain expert:** "Yes — put it in **Big Tech Moves** when it changes the platform, infrastructure, or policy reality builders have to work inside."
+>
+> **Dev:** "A submitted URL came in through the link form. Is that already a **Topic**?"
+> **Domain expert:** "No — it is a **Link** until it gets curated into a **Topic**, and one **Topic** may include many **Links**."
+>
+> **Dev:** "Does a submitted **Link** wait in a detached review queue?"
+> **Domain expert:** "No — it is a **Submission** for the target **Meetup** immediately, then the organizer can curate it into the board."
+>
+> **Dev:** "Does submitted copy have to appear exactly as written?"
+> **Domain expert:** "No — **Curation** can rewrite, combine, reframe, order, or move submitted material to make the board clearer."
+>
+> **Dev:** "Should **Topics** be sorted like a news feed?"
+> **Domain expert:** "No — **Curation** orders **Tracks** and **Topics** by the intended room discussion flow."
+>
+> **Dev:** "Can I reorder the standard **Tracks**?"
+> **Domain expert:** "Use the standard order by default, but change it when the specific **Meetup** flow calls for it."
+>
+> **Dev:** "Should **Showcases** appear by submission time?"
+> **Domain expert:** "No — **Curation** orders **Showcases** by organizer or in-room choice."
+>
+> **Dev:** "Can someone submit only a URL?"
+> **Domain expert:** "No — every **Submission** needs a title so the organizer can see the intended angle quickly."
+>
+> **Dev:** "Should the submitter pick a date?"
+> **Domain expert:** "No — every new **Submission** targets the next upcoming **Meetup** or **Meetup Slot**."
+>
+> **Dev:** "Should reminder copy point at a generated **Meetup Slot**?"
+> **Domain expert:** "No — **Reminders** should only point at an actual planned **Meetup**."
+>
+> **Dev:** "Can a **Showcase** include a repo, demo URL, and announcement post?"
+> **Domain expert:** "Yes — a **Showcase** can have many **Links**, but it can also be ad hoc and spontaneous."
+
+## Flagged ambiguities
+
+- "SHIPPED" was used as a temporary track name for launched work — resolved: launched member work belongs in **Local Builds & Projects**.
+- "local builds" was close to meaning any runnable project — resolved: **Local Builds & Projects** is for Austin/member/community-orbit work.
+- "session" was used for dated Austin AI Club gatherings — resolved: the canonical term is **Meetup** in docs, data, and UI code.
+- "future meetup" was used for generated calendar placeholders — resolved: tentative generated dates are **Meetup Slots** until manually overridden by hand-authored **Meetups**.
+- "biweekly" was close to being a hard schedule guarantee — resolved: it is the default planning cadence, and authored **Meetups** can override it.
+- "source of truth" was split between Markdown and structured data — resolved: the **Markdown Archive** is the durable record; **Meetup Data** is the curated rendering model.
+- "notes" was close to being treated as private facilitation material — resolved: **Presenter Notes** are public notes to self.
+- "showcase" was close to being treated as a **Track** — resolved: a **Showcase** belongs to the **Community Slot**, which appears after the standard **Tracks**.
+- "standard track" was close to meaning every track must appear every time — resolved: empty standard **Tracks** are omitted.
+- "empty community slot" was close to appearing on every **Meetup** — resolved: empty **Community Slots** appear only on the next upcoming **Meetup**.
+- "interesting AI news" was close to being enough for **Discussion Fit** — resolved: a **Topic** needs either unavoidable AI relevance or builder relevance through the club's cutting-edge, security, privacy, and open-source lens.
+- "adversarial" and "cutting-edge" were used descriptively, not as canonical domain terms — resolved: do not add them as separate lenses or Tracks.
+- "open source" was close to becoming another **Track** — resolved: the **Open Source Lens** shapes curation across existing **Tracks**.
+- "privacy" was close to becoming another **Track** — resolved: the **Privacy Lens** shapes curation across existing **Tracks**.
+- "security" was close to being only a **Track** — resolved: **Security** is both a standard **Track** and a **Security Lens**.
+- "big tech" was close to excluding policy and infrastructure — resolved: **Big Tech Moves** includes platform-scale policy, regulation, energy, export-control, and infrastructure changes when they shape AI development.
+- "link" was close to being treated as another name for **Topic** — resolved: **Links** are source material; **Topics** are curated discussion entries.
+- "topic without links" was considered — resolved: every **Topic** requires at least one **Link**.
+- "showcase without links" was considered — resolved: **Showcases** do not require **Links** because they can be ad hoc and spontaneous.
+- "submission" was close to being treated as pre-acceptance review state — resolved: **Submissions** are associated with their target **Meetup** immediately to keep contribution friction low.
+- "target meetup" was close to being user-selectable — resolved: new **Submissions** always target the next upcoming **Meetup** or **Meetup Slot**.
+- "reminder target" was close to following generated **Meetup Slots** — resolved: reminders only point at actual planned **Meetups**.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is optimized for clarity over abstraction. The goal is to make it easy
 - keep the Markdown Archive durable and easy to diff
 - support both archive browsing and Presentation Mode
 
-For the project language and curation rules, start with [CONTEXT.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/CONTEXT.md). The source-of-record decision is captured in [ADR 0001](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/docs/adr/0001-markdown-archive-as-source-of-record.md).
+For the project language and curation rules, start with [CONTEXT.md](./CONTEXT.md). The source-of-record decision is captured in [ADR 0001](./docs/adr/0001-markdown-archive-as-source-of-record.md).
 
 ## What the app does
 
@@ -42,7 +42,7 @@ npm run dev
 
 Then open the local Vite URL, usually `http://127.0.0.1:5173/`.
 
-If you want the inline reminder form to submit locally, copy [.env.example](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/.env.example) to `.env.local` and set `VITE_REMINDER_SIGNUP_URL`.
+If you want the inline reminder form to submit locally, copy [.env.example](./.env.example) to `.env.local` and set `VITE_REMINDER_SIGNUP_URL`.
 
 If you want the submission forms to create GitHub issues, also set:
 
@@ -70,29 +70,29 @@ Vercel deploy is intentionally simple:
 4. Output directory: `dist`
 5. Attach the `austinai.club` domain
 
-This repo also includes [vercel.json](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/vercel.json) so those settings are explicit in source control.
+This repo also includes [vercel.json](./vercel.json) so those settings are explicit in source control.
 
 Presentation Mode uses hash routes like `#/slides/...`, and the meetup/helper pages use pathname routes like `/meetups/2026-03-18` and `/submit-link`, so static hosting works with the included rewrites.
 
 ## Repo Map
 
-- [index.html](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/index.html)
+- [index.html](./index.html)
   Vite entry HTML
-- [src/main.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/main.jsx)
+- [src/main.jsx](./src/main.jsx)
   React bootstrap
-- [src/App.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/App.jsx)
+- [src/App.jsx](./src/App.jsx)
   Main renderer for archive mode, Presentation Mode, embeds, link cards, notes, and footer
-- [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js)
+- [src/data.js](./src/data.js)
   Explicit meetup data contract for rendering
-- [src/styles.css](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/styles.css)
+- [src/styles.css](./src/styles.css)
   Full visual system for both archive and presentation views
-- [scripts/sync-events.mjs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/scripts/sync-events.mjs)
+- [scripts/sync-events.mjs](./scripts/sync-events.mjs)
   Generates `public/meetups.json` plus per-event ICS files from `src/data.js`
-- [public/topics/](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/public/topics)
+- [public/topics/](./public/topics/)
   Durable Markdown Archive served as static files
-- [public/topics/README.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/public/topics/README.md)
+- [public/topics/README.md](./public/topics/README.md)
   Archive-side workflow notes
-- [apps-script/](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script)
+- [apps-script/](./apps-script/)
   Tiny Google Apps Script reminder backend
 - [api/github-issue.js](./api/github-issue.js)
   Vercel function for turning form submissions into GitHub issues
@@ -103,9 +103,9 @@ The render pipeline is:
 
 1. Durable meetup notes live in `public/topics/*.md`
 2. The Markdown Archive is the source of record for authored meetup notes
-3. Meetup data in [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js) mirrors or curates that content for rendering
-4. [src/App.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/App.jsx) renders archive mode and Presentation Mode from the same meetup data
-5. [src/styles.css](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/styles.css) styles both modes
+3. Meetup data in [src/data.js](./src/data.js) mirrors or curates that content for rendering
+4. [src/App.jsx](./src/App.jsx) renders archive mode and Presentation Mode from the same meetup data
+5. [src/styles.css](./src/styles.css) styles both modes
 
 This split is intentional:
 
@@ -115,7 +115,7 @@ This split is intentional:
 
 ## Data Shape
 
-Each meetup in [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js) contains:
+Each meetup in [src/data.js](./src/data.js) contains:
 
 - `id`
 - `slug`
@@ -200,11 +200,11 @@ Open source and privacy are curation lenses, not tracks. If a topic could fit mu
 
 ## Meetup Workflow
 
-1. Copy [public/topics/TEMPLATE.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/public/topics/TEMPLATE.md) to `public/topics/YYYY-MM-DD.md`
+1. Copy [public/topics/TEMPLATE.md](./public/topics/TEMPLATE.md) to `public/topics/YYYY-MM-DD.md`
 2. Use the standard five tracks unless there is a strong reason to diverge
 3. Omit empty tracks
 4. Add topics and links in Markdown first
-5. Mirror that content into [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js)
+5. Mirror that content into [src/data.js](./src/data.js)
 6. Add public `notes` when they help Presentation Mode
 7. Add or update the meetup `event` metadata if this is an actual planned meetup that should appear in reminders/calendar links
 8. Keep the Community Slot last; show an empty slot only for the next upcoming meetup
@@ -222,11 +222,11 @@ Meetup slots are not authored meetups: they do not have topic boards, and remind
 
 The reminder flow is intentionally small:
 
-1. Event metadata for actual planned meetups lives in [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js)
-2. [scripts/sync-events.mjs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/scripts/sync-events.mjs) generates:
+1. Event metadata for actual planned meetups lives in [src/data.js](./src/data.js)
+2. [scripts/sync-events.mjs](./scripts/sync-events.mjs) generates:
    `public/meetups.json` and `public/calendar/*.ics`
 3. The frontend posts one global email signup to `VITE_REMINDER_SIGNUP_URL`
-4. The Apps Script in [apps-script/README.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script/README.md) stores subscribers in a Google Sheet and sends reminders only for actual planned meetup days
+4. The Apps Script in [apps-script/README.md](./apps-script/README.md) stores subscribers in a Google Sheet and sends reminders only for actual planned meetup days
 
 ## Submissions
 
@@ -240,15 +240,15 @@ Submissions are intentionally low-friction:
 ## Embed Notes
 
 - The site should be served over HTTP, not opened with `file://`
-- X embeds are loaded client-side through Twitter widgets in [src/App.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/App.jsx)
+- X embeds are loaded client-side through Twitter widgets in [src/App.jsx](./src/App.jsx)
 - YouTube embeds use `referrerPolicy="strict-origin-when-cross-origin"` to reduce embed failures
 - Presentation Mode now auto-renders X posts, YouTube links, and direct image URLs from `href` / `linkPair` unless suppressed
 - If an embed is flaky, keep the direct link in the data model so the topic still degrades gracefully
 
 ## Editing Guidance
 
-- Prefer editing [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js) over adding new component abstractions
+- Prefer editing [src/data.js](./src/data.js) over adding new component abstractions
 - Prefer adding a new data shape only if an existing one cannot express the topic cleanly
 - Keep comments short and structural
-- Keep CSS centralized in [src/styles.css](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/styles.css) unless a split becomes obviously necessary
+- Keep CSS centralized in [src/styles.css](./src/styles.css) unless a split becomes obviously necessary
 - Optimize for coherence across both archive mode and Presentation Mode

--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
 # austin-ai-meetup-list
 
-A small Vite + React frontend for the Austin AI Club topic board.
+A small Vite + React frontend for Austin AI Club meetups, topic boards, submissions, reminders, and presentation mode.
 
 This repo is optimized for clarity over abstraction. The goal is to make it easy for a human or agent to:
 
 - understand the rendering model quickly
-- add or update club stories without guessing
-- keep the archive durable in Markdown
-- support both archive browsing and presentation/slideshow mode
+- add or update meetup topic boards without guessing
+- keep the Markdown Archive durable and easy to diff
+- support both archive browsing and Presentation Mode
 
-Right now the repo only contains the real March 18, 2026 club session. The earlier fake February seed content has been removed.
+For the project language and curation rules, start with [CONTEXT.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/CONTEXT.md). The source-of-record decision is captured in [ADR 0001](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/docs/adr/0001-markdown-archive-as-source-of-record.md).
 
 ## What the app does
 
-The frontend has three surfaces over the same content:
+The frontend has three public surfaces over the same meetup data:
 
 - Homepage: a browsable index of meetups
-- Meetup detail view: a dedicated page for one meetup with all tracks and stories expanded
-- Presentation view: a slide-by-slide walkthrough of each story, including richer embeds, link cards, and optional presenter notes
+- Meetup detail view: a dedicated page for one meetup with its topic board expanded
+- Presentation Mode: a slide-by-slide walkthrough of each topic and showcase, including richer embeds, link cards, and public presenter notes
 
 It also has three auxiliary pages:
 
-- `/calendar` for upcoming meetup slots
-- `/submit-link` for regular link submissions
+- `/calendar` for authored meetups and tentative meetup slots
+- `/submit-link` for link submissions
 - `/submit-showcase` for short member-led showcase proposals
 
 Meetup detail pages live at `/meetups/:slug`.
 
-The slideshow is not a separate data source. It is built from the same session data that powers both the homepage and meetup detail pages.
+Presentation Mode is not a separate data source. It is built from the same meetup data that powers both the homepage and meetup detail pages.
 
-The site also supports one global meetup reminder signup. Events stay hardcoded in source control, while a tiny Google Apps Script can collect emails and send day-of reminders.
+The site also supports low-friction submissions and one global reminder signup. Submissions target the next upcoming authored meetup or tentative meetup slot. Reminders only point at actual planned meetups, not tentative meetup slots.
 
-The slideshow also uses hash-based slide URLs such as `/meetups/2026-03-18#/slides/2026-03-18/models-and-research/qwen-3-5-series`, so refresh and direct links return to the same item without needing server-side rendering.
+Presentation Mode uses hash-based slide URLs such as `/meetups/2026-03-18#/slides/2026-03-18/models-and-research/qwen-3-5-series`, so refresh and direct links return to the same item without needing server-side rendering.
 
 ## Quick Start
 
@@ -42,7 +42,7 @@ npm run dev
 
 Then open the local Vite URL, usually `http://127.0.0.1:5173/`.
 
-If you want the inline reminder form to submit locally, copy [.env.example](/Users/plebdev/Desktop/code/austin-ai-meetup-list/.env.example) to `.env.local` and set `VITE_REMINDER_SIGNUP_URL`.
+If you want the inline reminder form to submit locally, copy [.env.example](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/.env.example) to `.env.local` and set `VITE_REMINDER_SIGNUP_URL`.
 
 If you want the submission forms to create GitHub issues, also set:
 
@@ -70,29 +70,29 @@ Vercel deploy is intentionally simple:
 4. Output directory: `dist`
 5. Attach the `austinai.club` domain
 
-This repo also includes [vercel.json](/Users/plebdev/Desktop/code/austin-ai-meetup-list/vercel.json) so those settings are explicit in source control.
+This repo also includes [vercel.json](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/vercel.json) so those settings are explicit in source control.
 
-The slideshow uses hash routes like `#/slides/...`, and the meetup/helper pages use pathname routes like `/meetups/2026-03-18` and `/submit-link`, so static hosting works with the included rewrites.
+Presentation Mode uses hash routes like `#/slides/...`, and the meetup/helper pages use pathname routes like `/meetups/2026-03-18` and `/submit-link`, so static hosting works with the included rewrites.
 
 ## Repo Map
 
-- [index.html](/Users/plebdev/Desktop/code/austin-ai-meetup-list/index.html)
+- [index.html](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/index.html)
   Vite entry HTML
-- [src/main.jsx](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/main.jsx)
+- [src/main.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/main.jsx)
   React bootstrap
-- [src/App.jsx](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/App.jsx)
-  Main renderer for archive mode, presentation mode, embeds, link cards, notes, and footer
-- [src/data.js](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/data.js)
-  Explicit content contract for the frontend
-- [src/styles.css](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/styles.css)
+- [src/App.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/App.jsx)
+  Main renderer for archive mode, Presentation Mode, embeds, link cards, notes, and footer
+- [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js)
+  Explicit meetup data contract for rendering
+- [src/styles.css](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/styles.css)
   Full visual system for both archive and presentation views
-- [scripts/sync-events.mjs](/Users/plebdev/Desktop/code/austin-ai-meetup-list/scripts/sync-events.mjs)
+- [scripts/sync-events.mjs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/scripts/sync-events.mjs)
   Generates `public/meetups.json` plus per-event ICS files from `src/data.js`
-- [public/topics/](/Users/plebdev/Desktop/code/austin-ai-meetup-list/public/topics)
-  Durable Markdown archive served as static files
-- [public/topics/README.md](/Users/plebdev/Desktop/code/austin-ai-meetup-list/public/topics/README.md)
+- [public/topics/](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/public/topics)
+  Durable Markdown Archive served as static files
+- [public/topics/README.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/public/topics/README.md)
   Archive-side workflow notes
-- [apps-script/](/Users/plebdev/Desktop/code/austin-ai-meetup-list/apps-script)
+- [apps-script/](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script)
   Tiny Google Apps Script reminder backend
 - [api/github-issue.js](./api/github-issue.js)
   Vercel function for turning form submissions into GitHub issues
@@ -101,30 +101,32 @@ The slideshow uses hash routes like `#/slides/...`, and the meetup/helper pages 
 
 The render pipeline is:
 
-1. Durable club notes live in `public/topics/*.md`
-2. UI data in [src/data.js](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/data.js) mirrors or curates that content for the frontend
-3. [src/App.jsx](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/App.jsx) renders archive mode and presentation mode from the same session data
-4. [src/styles.css](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/styles.css) styles both modes
+1. Durable meetup notes live in `public/topics/*.md`
+2. The Markdown Archive is the source of record for authored meetup notes
+3. Meetup data in [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js) mirrors or curates that content for rendering
+4. [src/App.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/App.jsx) renders archive mode and Presentation Mode from the same meetup data
+5. [src/styles.css](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/styles.css) styles both modes
 
 This split is intentional:
 
-- Markdown stays durable and easy to diff
-- `data.js` stays explicit and patch-friendly
-- React stays mostly presentational, with only a little view state for slideshow mode
+- the Markdown Archive stays durable and easy to diff
+- meetup data stays explicit and patch-friendly
+- React stays mostly presentational, with only a little view state for Presentation Mode
 
 ## Data Shape
 
-Each session in [src/data.js](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/data.js) contains:
+Each meetup in [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js) contains:
 
 - `id`
 - `slug`
 - `date`
-- `open`
 - `markdownHref`
 - `event`
+- `presentationIntro`
+- `showcases[]`
 - `tracks[]`
 
-`event` is optional meetup metadata for reminder emails and add-to-calendar links:
+`event` is optional event metadata for calendar links and reminders:
 
 - `title`
 - `summary`
@@ -141,7 +143,7 @@ Each track contains:
 - `title`
 - `items[]`
 
-Each topic item can use any of these fields:
+Each topic must have at least one link via `href`, `linkPair`, or another link-bearing presentation shape. A topic item can use any of these fields:
 
 - `title`
 - `description`
@@ -165,13 +167,13 @@ Supported patterns right now:
 - Explicit X/Twitter embed override via `embed` or `embeds`
 - Explicit image override via `image` or `images`
 - Explicit YouTube embed override via `video` or `videos`
-- Paired story via `mediaPair`, usually `video + reaction post`
-- Presenter note via `notes`
+- Paired topic via `mediaPair`, usually `video + reaction post`
+- Public presenter note via `notes`
 - Opt out of defaults with `suppressXEmbeds`, `suppressVideos`, or `suppressImages`
 
-## Standard Categories
+## Standard Tracks
 
-Meetups should use the same five high-level buckets by default:
+Meetups should use the same five high-level tracks by default:
 
 1. `Local Builds & Projects`
 2. `Agent Infrastructure`
@@ -179,58 +181,74 @@ Meetups should use the same five high-level buckets by default:
 4. `Security`
 5. `Big Tech Moves`
 
-These names are intentionally broad enough to survive week-to-week topic drift while still being specific enough to keep the board organized.
+These names are intentionally broad enough to survive meetup-to-meetup topic drift while still being specific enough to keep the board organized. Empty standard tracks should be omitted.
 
 Use them this way:
 
 - `Local Builds & Projects`
-  New repos, demos, local stacks, prototypes, and things people can run or inspect directly.
+  Austin/member/community-orbit projects, demos, prototypes, launches, and things people can run or inspect directly.
 - `Agent Infrastructure`
   CLIs, runtimes, orchestration frameworks, protocols, interfaces, tool-calling layers, and deployment plumbing.
 - `Models & Research`
   Model releases, benchmark shifts, papers, frontier comparisons, architecture updates, and capability discussions.
 - `Security`
-  Attacks, red-team findings, prompt injection, abuse patterns, defensive ideas, and security-relevant failures.
+  Attacks, red-team findings, prompt injection, abuse patterns, defensive ideas, and security-relevant failures. Security is also a curation lens across other tracks.
 - `Big Tech Moves`
-  Major company moves, hardware launches, ecosystem shifts, OS/platform bets, acquisitions, and product strategy.
+  Major company moves, hardware launches, ecosystem shifts, OS/platform bets, acquisitions, product strategy, and platform-scale policy or infrastructure changes.
 
-If a story could fit multiple buckets, sort it by the angle you want the club discussion to focus on, not by every possible interpretation.
+Open source and privacy are curation lenses, not tracks. If a topic could fit multiple tracks, sort it by the angle you want the club discussion to focus on, not by every possible interpretation.
 
-## Monthly Workflow
+## Meetup Workflow
 
-1. Copy [public/topics/TEMPLATE.md](/Users/plebdev/Desktop/code/austin-ai-meetup-list/public/topics/TEMPLATE.md) to `public/topics/YYYY-MM-DD.md`
-2. Use the standard five categories unless there is a strong reason to diverge
-3. Add the club stories and source links in Markdown first
-4. Mirror that content into [src/data.js](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/data.js)
-5. Add `notes` only when they help in presentation mode
-6. Add or update the session `event` metadata if this meetup should appear in reminders/calendar links
-7. The homepage is just the meetup index, and meetup detail pages render their tracks expanded by default
-8. Run `npm run build`
+1. Copy [public/topics/TEMPLATE.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/public/topics/TEMPLATE.md) to `public/topics/YYYY-MM-DD.md`
+2. Use the standard five tracks unless there is a strong reason to diverge
+3. Omit empty tracks
+4. Add topics and links in Markdown first
+5. Mirror that content into [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js)
+6. Add public `notes` when they help Presentation Mode
+7. Add or update the meetup `event` metadata if this is an actual planned meetup that should appear in reminders/calendar links
+8. Keep the Community Slot last; show an empty slot only for the next upcoming meetup
+9. Run `npm run build`
 
-Do not skip the Markdown step. Markdown is the archive of record.
+Do not skip the Markdown step. The Markdown Archive is the source of record.
+
+## Meetup Slots
+
+Austin AI Club tries to meet biweekly. The calendar can generate tentative meetup slots from that cadence, and those slots can be manually overridden by authored meetups when the real date changes.
+
+Meetup slots are not authored meetups: they do not have topic boards, and reminders should not point at them. Submissions can still target the next meetup slot when no authored meetup exists yet, keeping the submission path low-friction.
 
 ## Reminders
 
 The reminder flow is intentionally small:
 
-1. Meetup metadata lives in [src/data.js](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/data.js)
-2. [scripts/sync-events.mjs](/Users/plebdev/Desktop/code/austin-ai-meetup-list/scripts/sync-events.mjs) generates:
+1. Event metadata for actual planned meetups lives in [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js)
+2. [scripts/sync-events.mjs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/scripts/sync-events.mjs) generates:
    `public/meetups.json` and `public/calendar/*.ics`
 3. The frontend posts one global email signup to `VITE_REMINDER_SIGNUP_URL`
-4. The Apps Script in [apps-script/README.md](/Users/plebdev/Desktop/code/austin-ai-meetup-list/apps-script/README.md) stores subscribers in a Google Sheet and sends reminders on meetup days
+4. The Apps Script in [apps-script/README.md](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script/README.md) stores subscribers in a Google Sheet and sends reminders only for actual planned meetup days
+
+## Submissions
+
+Submissions are intentionally low-friction:
+
+- new submissions always target the next upcoming authored meetup or tentative meetup slot
+- link submissions require a title and one or more valid links
+- showcase submissions require a title and short description; links are optional because showcases can be ad hoc and spontaneous
+- curation can rewrite, combine, reframe, order, or move submitted material before it becomes part of a topic board
 
 ## Embed Notes
 
 - The site should be served over HTTP, not opened with `file://`
-- X embeds are loaded client-side through Twitter widgets in [src/App.jsx](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/App.jsx)
+- X embeds are loaded client-side through Twitter widgets in [src/App.jsx](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/App.jsx)
 - YouTube embeds use `referrerPolicy="strict-origin-when-cross-origin"` to reduce embed failures
-- Presentation mode now auto-renders X posts, YouTube links, and direct image URLs from `href` / `linkPair` unless suppressed
-- If an embed is flaky, keep the direct link in the data model so the story still degrades gracefully
+- Presentation Mode now auto-renders X posts, YouTube links, and direct image URLs from `href` / `linkPair` unless suppressed
+- If an embed is flaky, keep the direct link in the data model so the topic still degrades gracefully
 
 ## Editing Guidance
 
-- Prefer editing [src/data.js](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/data.js) over adding new component abstractions
-- Prefer adding a new data shape only if an existing one cannot express the story cleanly
+- Prefer editing [src/data.js](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/data.js) over adding new component abstractions
+- Prefer adding a new data shape only if an existing one cannot express the topic cleanly
 - Keep comments short and structural
-- Keep CSS centralized in [src/styles.css](/Users/plebdev/Desktop/code/austin-ai-meetup-list/src/styles.css) unless a split becomes obviously necessary
-- Optimize for coherence across both archive mode and presentation mode
+- Keep CSS centralized in [src/styles.css](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/src/styles.css) unless a split becomes obviously necessary
+- Optimize for coherence across both archive mode and Presentation Mode

--- a/api/github-issue.js
+++ b/api/github-issue.js
@@ -1,5 +1,5 @@
-import { sessions } from "../src/data.js";
-import { nextMeetupFromSessions } from "../src/meetups.js";
+import { meetups } from "../src/data.js";
+import { getNextSubmissionTarget } from "../src/features/calendar/calendar.js";
 import { parseSubmissionLinks } from "../src/features/submissions/links.js";
 
 const DEFAULT_REPO_OWNER = "AustinKelsay";
@@ -9,12 +9,13 @@ function trimString(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function getNextMeetup() {
-  return nextMeetupFromSessions(sessions);
-}
+function getTargetLabel(target) {
+  const dateLabel = target.date ?? new Intl.DateTimeFormat("en-US", {
+    dateStyle: "long",
+    timeZone: target.event.timezone ?? "America/Chicago",
+  }).format(new Date(target.event.startAt));
 
-function getMeetupLabel(session) {
-  return `${session.date} · ${session.event.locationName}`;
+  return `${dateLabel} · ${target.event.locationName}`;
 }
 
 function isValidHttpUrl(value) {
@@ -39,16 +40,16 @@ function formatLinksForIssue(links) {
 
 function buildIssuePayload(input) {
   const submittedAt = new Date().toISOString();
-  const meetupLine = `Meetup: ${input.meetupLabel} (${input.meetupSlug})`;
+  const targetLine = `Target: ${input.targetLabel} (${input.targetSlug}, ${input.targetKind})`;
 
   if (input.kind === "link") {
     return {
-      title: `[${input.meetupSlug}] [Link] ${input.title}`,
+      title: `[${input.targetSlug}] [Link] ${input.title}`,
       labels: ["link"],
       body: [
-        "New meetup link submission.",
+        "New link submission.",
         "",
-        meetupLine,
+        targetLine,
         `Title: ${input.title}`,
         ...formatLinksForIssue(input.links),
         "",
@@ -59,12 +60,12 @@ function buildIssuePayload(input) {
   }
 
   return {
-    title: `[${input.meetupSlug}] [Showcase] ${input.title}`,
+      title: `[${input.targetSlug}] [Showcase] ${input.title}`,
     labels: ["showcase"],
     body: [
       "New showcase submission.",
       "",
-      meetupLine,
+      targetLine,
       `Title: ${input.title}`,
       "",
       "Summary:",
@@ -116,9 +117,9 @@ export default async function handler(request, response) {
     return;
   }
 
-  const meetup = getNextMeetup();
-  if (!meetup) {
-    response.status(503).json({ error: "No upcoming meetup is configured." });
+  const target = getNextSubmissionTarget(meetups);
+  if (!target) {
+    response.status(503).json({ error: "No upcoming meetup or meetup slot is configured." });
     return;
   }
 
@@ -138,8 +139,9 @@ export default async function handler(request, response) {
     links,
     description,
     pageUrl,
-    meetupSlug: meetup.slug,
-    meetupLabel: getMeetupLabel(meetup),
+    targetSlug: target.slug,
+    targetKind: target.kind,
+    targetLabel: getTargetLabel(target),
   });
 
   let githubResponse;

--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -1,13 +1,13 @@
 # Apps Script Reminder Backend
 
-This folder is the tiny backend for the inline reminder signup on `austinai.club`.
+This folder is the tiny backend for the inline Reminder signup on `austinai.club`.
 
 It does four things:
 
 1. Accepts one global email signup from the site
 2. Stores subscribers in a Google Sheet
 3. Fetches the static meetup feed from `https://austinai.club/meetups.json`
-4. Sends one reminder email on meetup days around 10:00 AM CT
+4. Sends one Reminder email on actual planned Meetup days around 10:00 AM CT
 
 ## What to configure
 
@@ -25,7 +25,7 @@ Set these script properties before deploying:
 ## Recommended setup
 
 1. Create a new Apps Script project
-2. Paste in [Code.gs](/Users/plebdev/Desktop/code/austin-ai-meetup-list/apps-script/Code.gs)
+2. Paste in [Code.gs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script/Code.gs)
 3. Set the script properties above
 4. Run `setupReminderSheets()` once
 5. Deploy as a web app
@@ -41,7 +41,7 @@ To verify the full flow with a real inbox email:
 
 1. Re-submit your email from the local site
    This updates your row so you become the most recently active subscriber.
-2. Copy the latest `sendSmokeTestReminder()` helpers from [Code.gs](/Users/plebdev/Desktop/code/austin-ai-meetup-list/apps-script/Code.gs) into your Apps Script project and save
+2. Copy the latest `sendSmokeTestReminder()` helpers from [Code.gs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script/Code.gs) into your Apps Script project and save
 3. In the Apps Script editor, run `sendSmokeTestReminder()`
 4. Check your inbox for a message with the subject `Austin AI Club Smoke Test today at ...`
 

--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -25,7 +25,7 @@ Set these script properties before deploying:
 ## Recommended setup
 
 1. Create a new Apps Script project
-2. Paste in [Code.gs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script/Code.gs)
+2. Paste in [Code.gs](Code.gs)
 3. Set the script properties above
 4. Run `setupReminderSheets()` once
 5. Deploy as a web app
@@ -41,7 +41,7 @@ To verify the full flow with a real inbox email:
 
 1. Re-submit your email from the local site
    This updates your row so you become the most recently active subscriber.
-2. Copy the latest `sendSmokeTestReminder()` helpers from [Code.gs](/Users/plebdev/Desktop/code/learning/austin-ai-meetup-list/apps-script/Code.gs) into your Apps Script project and save
+2. Copy the latest `sendSmokeTestReminder()` helpers from [Code.gs](Code.gs) into your Apps Script project and save
 3. In the Apps Script editor, run `sendSmokeTestReminder()`
 4. Check your inbox for a message with the subject `Austin AI Club Smoke Test today at ...`
 

--- a/docs/adr/0001-markdown-archive-as-source-of-record.md
+++ b/docs/adr/0001-markdown-archive-as-source-of-record.md
@@ -1,0 +1,3 @@
+# Markdown Archive as source of record
+
+Austin AI Club meetup notes live first in the Markdown Archive, while Meetup Data is the structured rendering model used by the website and Presentation Mode. This keeps the durable record easy to read, diff, and preserve outside the React app, while still allowing curated data shapes for embeds, slides, calendar metadata, and public Presenter Notes. When Markdown and Meetup Data disagree, treat the Markdown Archive as the source of record and update Meetup Data to render the intended board.

--- a/public/meetups.json
+++ b/public/meetups.json
@@ -4,7 +4,7 @@
   "events": [
     {
       "id": "2026-04-15",
-      "sessionId": "session-2026-04-15",
+      "meetupId": "meetup-2026-04-15",
       "slug": "2026-04-15",
       "dateLabel": "April 15, 2026",
       "markdownHref": "./topics/2026-04-15.md",
@@ -22,7 +22,7 @@
     },
     {
       "id": "2026-04-01",
-      "sessionId": "session-2026-04-01",
+      "meetupId": "meetup-2026-04-01",
       "slug": "2026-04-01",
       "dateLabel": "April 1, 2026",
       "markdownHref": "./topics/2026-04-01.md",
@@ -40,7 +40,7 @@
     },
     {
       "id": "2026-03-18",
-      "sessionId": "session-2026-03-18",
+      "meetupId": "meetup-2026-03-18",
       "slug": "2026-03-18",
       "dateLabel": "March 18, 2026",
       "markdownHref": "./topics/2026-03-18.md",

--- a/public/topics/2026-04-01.md
+++ b/public/topics/2026-04-01.md
@@ -2,9 +2,6 @@
 
 ## April 1, 2026
 
-### SHIPPED
-- **Anyone else?** - What did you ship this month? Bring one concrete thing — a feature, a workflow, a client win, whatever. Anyone else?
-
 ### Agent Infrastructure
 - **GTC 2026 was an AI factory pitch** - The main pitch was not just faster chips. NVIDIA framed GTC around the whole AI factory, from Vera Rubin racks to DSX reference designs  
   Source: https://blogs.nvidia.com/blog/gtc-2026-news/  

--- a/public/topics/README.md
+++ b/public/topics/README.md
@@ -1,8 +1,8 @@
 # Austin AI Club Meetup Notes
 
-This folder is the durable Markdown archive for each Austin AI Club meetup.
+This folder is the durable Markdown Archive for each Austin AI Club meetup.
 
-The frontend reads curated session data from `src/data.js`, but the source-of-record notes for every meetup should also live here as standalone Markdown.
+The Markdown Archive is the source of record for authored meetup notes. The frontend reads curated Meetup Data from `src/data.js`, but that data should mirror or intentionally curate from these standalone Markdown files.
 
 ## Meetups
 
@@ -13,14 +13,15 @@ The frontend reads curated session data from `src/data.js`, but the source-of-re
 ## Adding a new meetup
 
 1. Copy `TEMPLATE.md` to `YYYY-MM-DD.md`.
-2. Add the meetup tracks, stories, and source links in Markdown.
-3. Update `src/data.js` so the frontend matches the Markdown notes.
-4. Add presenter `notes` only if they help in slideshow mode.
-5. Keep the Markdown archive and frontend data in sync.
+2. Add the meetup Topic Board: Tracks, Topics, Links, and any Showcases.
+3. Omit empty standard Tracks.
+4. Update `src/data.js` so the frontend matches or intentionally curates from the Markdown notes.
+5. Add public presenter `notes` only if they help Presentation Mode.
+6. Keep the Community Slot last, and show an empty slot only for the next upcoming meetup.
 
-## Standard categories
+## Standard Tracks
 
-Use the same five categories each meetup unless there is a strong reason not to:
+Use the same five Tracks each meetup unless there is a strong reason not to:
 
 1. `Local Builds & Projects`
 2. `Agent Infrastructure`
@@ -28,4 +29,4 @@ Use the same five categories each meetup unless there is a strong reason not to:
 4. `Security`
 5. `Big Tech Moves`
 
-These categories are meant to stay stable across meetups so new stories always have an obvious home.
+These Tracks are meant to stay stable across meetups so new Topics have an obvious home. Open source and privacy are curation lenses, not Tracks. Security is both a Track and a curation lens.

--- a/public/topics/TEMPLATE.md
+++ b/public/topics/TEMPLATE.md
@@ -3,27 +3,31 @@
 ## Month DD, YYYY
 
 ### Local Builds & Projects
-- **Topic title** - New open source project, app, local stack, or demo worth showing
-  Source: https://example.com
+- **Topic title** - Austin/member/community-orbit project, demo, prototype, launch, or local build
+  Link: https://example.com
 
 ### Agent Infrastructure
 - **Topic title** - Agent tooling, protocols, orchestration, interfaces, or runtime infra
-  Source: https://example.com
+  Link: https://example.com
 
 ### Models & Research
 - **Topic title** - Model release, benchmark, paper, or capability update
-  Source: https://example.com
+  Link: https://example.com
 
 ### Security
 - **Topic title** - Attack, eval, benchmark, safety issue, or reliability finding
-  Source: https://example.com
+  Link: https://example.com
 
 ### Big Tech Moves
-- **Topic title** - Major company move, hardware release, product launch, or market shift
-  Source: https://example.com
+- **Topic title** - Major company move, hardware launch, platform bet, policy change, or infrastructure shift
+  Link: https://example.com
 
-## Optional notes for frontend curation
+### Showcase
+- **Showcase title** - Optional member-led share for the Community Slot
+  Link: https://example.com
+
+## Optional notes for Meetup Data curation
 
 - **Topic title** - One-line why this matters
-  Source: https://example.com
-  Notes: Short presenter note if needed for slideshow mode
+  Link: https://example.com
+  Notes: Public Presenter Notes if needed for Presentation Mode

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { sessions } from "../src/data.js";
+import { meetups } from "../src/data.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,19 +68,19 @@ function buildIcsBody(event, detailsUrl) {
 }
 
 function collectEvents() {
-  return sessions
-    .filter((session) => session.event)
-    .map((session) => {
-      const event = session.event;
-      const detailsUrl = `${siteUrl}${buildMeetupPath(session.slug)}`;
-      const icsPath = `/calendar/${session.slug}.ics`;
+  return meetups
+    .filter((meetup) => meetup.event)
+    .map((meetup) => {
+      const event = meetup.event;
+      const detailsUrl = `${siteUrl}${buildMeetupPath(meetup.slug)}`;
+      const icsPath = `/calendar/${meetup.slug}.ics`;
 
       return {
-        id: session.slug,
-        sessionId: session.id,
-        slug: session.slug,
-        dateLabel: session.date,
-        markdownHref: session.markdownHref,
+        id: meetup.slug,
+        meetupId: meetup.id,
+        slug: meetup.slug,
+        dateLabel: meetup.date,
+        markdownHref: meetup.markdownHref,
         title: event.title,
         summary: event.summary,
         startAt: event.startAt,
@@ -92,7 +92,7 @@ function collectEvents() {
         detailsUrl,
         googleCalendarUrl: buildGoogleCalendarUrl({
           ...event,
-          id: session.slug,
+          id: meetup.slug,
         }),
         icsUrl: `${siteUrl}${icsPath}`,
         icsPath,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
-import { sessions } from "./data.js";
+import { meetups } from "./data.js";
 import { APP_ROUTE } from "./app/constants.js";
 import { buildMeetupPath, getAppRoute, setPathname } from "./app/routes.js";
 import ArchiveView from "./features/archive/ArchiveView.jsx";
 import MeetupDetailView from "./features/archive/MeetupDetailView.jsx";
 import {
   buildCalendarEntries,
-  getNextSubmissionMeetup,
+  getNextSubmissionTarget,
 } from "./features/calendar/calendar.js";
 import CalendarView from "./features/calendar/CalendarView.jsx";
 import PresentationMode from "./features/presentation/PresentationMode.jsx";
@@ -24,19 +24,22 @@ const PRESENTATION_ENTRY_MODE = {
 };
 
 export default function App() {
+  const nextSubmissionTarget = getNextSubmissionTarget(meetups);
+  const nextMeetup = meetups.find((meetup) => meetup.id === nextSubmissionTarget?.id) ?? null;
   const [presentationState, setPresentationState] = useState(() =>
-    resolvePresentationHash(sessions, window.location.hash),
+    resolvePresentationHash(meetups, window.location.hash, {
+      includeOpenCommunitySlotForMeetupId: nextMeetup?.id ?? null,
+    }),
   );
   const [route, setRoute] = useState(() => getAppRoute(window.location.pathname));
-  const calendarEntries = buildCalendarEntries(sessions);
-  const nextMeetup = getNextSubmissionMeetup(sessions);
-  const nextCalendarEntry =
-    calendarEntries.find((entry) => new Date(entry.event.endAt).getTime() >= Date.now()) ?? null;
+  const calendarEntries = buildCalendarEntries(meetups);
 
   const syncLocationState = (pathname = window.location.pathname, hash = window.location.hash) => {
     let nextRoute = getAppRoute(pathname);
 
-    const next = resolvePresentationHash(sessions, hash);
+    const next = resolvePresentationHash(meetups, hash, {
+      includeOpenCommunitySlotForMeetupId: nextMeetup?.id ?? null,
+    });
     if (next?.invalidHash !== undefined) {
       setRoute(nextRoute);
       setPresentationState(null);
@@ -49,9 +52,9 @@ export default function App() {
     if (
       next &&
       nextRoute.name === APP_ROUTE.MEETUP &&
-      nextRoute.meetupSlug !== next.session.slug
+      nextRoute.meetupSlug !== next.meetup.slug
     ) {
-      const normalizedPath = buildMeetupPath(next.session.slug);
+      const normalizedPath = buildMeetupPath(next.meetup.slug);
       setPathname(normalizedPath, { replace: true, hash });
       nextRoute = getAppRoute(normalizedPath);
     }
@@ -69,13 +72,13 @@ export default function App() {
     openRoute("/", options);
   };
 
-  const goToMeetup = (session, options = {}) => {
-    if (!session?.slug) {
+  const goToMeetup = (meetup, options = {}) => {
+    if (!meetup?.slug) {
       goHome(options);
       return;
     }
 
-    openRoute(buildMeetupPath(session.slug), options);
+    openRoute(buildMeetupPath(meetup.slug), options);
   };
 
   const goToNextMeetupOrHome = (options = {}) => {
@@ -135,8 +138,9 @@ export default function App() {
     };
   }, [route, nextMeetup]);
 
-  const openPresentation = (session, slideIndex = 0, options = {}) => {
-    const slides = buildSlides(session);
+  const openPresentation = (meetup, slideIndex = 0, options = {}) => {
+    const includeOpenCommunitySlot = meetup.id === nextMeetup?.id;
+    const slides = buildSlides(meetup, { includeOpenCommunitySlot });
     const slide = slides[slideIndex];
     if (!slide) {
       return;
@@ -148,7 +152,7 @@ export default function App() {
       replace = false,
       returnHash = "",
     } = options;
-    const returnPath = buildMeetupPath(session.slug);
+    const returnPath = buildMeetupPath(meetup.slug);
     const currentPresentationState = getPresentationHistoryState();
     const isAlreadyInPresentation = window.location.hash.startsWith("#/slides/");
 
@@ -185,41 +189,42 @@ export default function App() {
     }
 
     setPathname(returnPath, {
-      hash: buildSlideHash(session, slide),
+      hash: buildSlideHash(meetup, slide),
       replace: nextReplace,
       state: nextState,
     });
     syncLocationState();
   };
 
-  const openPresentationFromItem = (session, item, returnHash) => {
-    const slideIndex = findTopicSlideIndex(session, item);
+  const openPresentationFromItem = (meetup, item, returnHash) => {
+    const includeOpenCommunitySlot = meetup.id === nextMeetup?.id;
+    const slideIndex = findTopicSlideIndex(meetup, item, { includeOpenCommunitySlot });
     if (slideIndex === -1) {
       return;
     }
 
-    const returnPath = buildMeetupPath(session.slug);
+    const returnPath = buildMeetupPath(meetup.slug);
     setPathname(returnPath, {
       hash: returnHash,
       replace: true,
       state: window.history.state,
     });
 
-    openPresentation(session, slideIndex, {
+    openPresentation(meetup, slideIndex, {
       entryMode: PRESENTATION_ENTRY_MODE.ITEM,
       hasReturnEntry: true,
       returnHash,
     });
   };
 
-  const closePresentation = (session) => {
+  const closePresentation = (meetup) => {
     const presentationState = getPresentationHistoryState();
     if (presentationState?.hasReturnEntry && presentationState?.depth) {
       window.history.go(-presentationState.depth);
       return;
     }
 
-    goToMeetup(session, {
+    goToMeetup(meetup, {
       replace: true,
       hash: presentationState?.returnHash ?? "",
     });
@@ -229,7 +234,7 @@ export default function App() {
     return (
       <CalendarView
         calendarEntries={calendarEntries}
-        nextSession={nextCalendarEntry}
+        nextMeetup={nextMeetup}
         onClose={() => goToNextMeetupOrHome({ replace: true })}
         onOpenRoute={openRoute}
       />
@@ -240,7 +245,7 @@ export default function App() {
     return (
       <SubmissionScreen
         kind="link"
-        meetup={nextMeetup}
+        target={nextSubmissionTarget}
         onBack={() => goToNextMeetupOrHome({ replace: true })}
         onOpenRoute={openRoute}
       />
@@ -251,7 +256,7 @@ export default function App() {
     return (
       <SubmissionScreen
         kind="showcase"
-        meetup={nextMeetup}
+        target={nextSubmissionTarget}
         onBack={() => goToNextMeetupOrHome({ replace: true })}
         onOpenRoute={openRoute}
       />
@@ -259,12 +264,12 @@ export default function App() {
   }
 
   if (route.name === APP_ROUTE.MEETUP) {
-    const session = sessions.find((candidate) => candidate.slug === route.meetupSlug) ?? null;
+    const meetup = meetups.find((candidate) => candidate.slug === route.meetupSlug) ?? null;
 
     return (
       <>
         <MeetupDetailView
-          session={session}
+          meetup={meetup}
           meetupSlug={route.meetupSlug}
           nextMeetupId={nextMeetup?.id ?? null}
           onOpenRoute={openRoute}
@@ -280,15 +285,16 @@ export default function App() {
             })
           }
           onOpenTopicPresentation={(item, topicId) =>
-            openPresentationFromItem(session, item, `#${topicId}`)
+            openPresentationFromItem(meetup, item, `#${topicId}`)
           }
         />
-        {presentationState?.session ? (
+        {presentationState?.meetup ? (
           <PresentationMode
-            session={presentationState.session}
+            meetup={presentationState.meetup}
             currentIndex={presentationState.slideIndex}
-            onNavigate={(slideIndex) => openPresentation(presentationState.session, slideIndex)}
-            onExit={() => closePresentation(presentationState.session)}
+            includeOpenCommunitySlot={presentationState.meetup.id === nextMeetup?.id}
+            onNavigate={(slideIndex) => openPresentation(presentationState.meetup, slideIndex)}
+            onExit={() => closePresentation(presentationState.meetup)}
           />
         ) : null}
       </>
@@ -298,15 +304,17 @@ export default function App() {
   return (
     <>
       <ArchiveView
-        sessions={sessions}
+        meetups={meetups}
+        nextMeetupId={nextMeetup?.id ?? null}
         onOpenRoute={openRoute}
       />
-      {presentationState?.session ? (
+      {presentationState?.meetup ? (
         <PresentationMode
-          session={presentationState.session}
+          meetup={presentationState.meetup}
           currentIndex={presentationState.slideIndex}
-          onNavigate={(slideIndex) => openPresentation(presentationState.session, slideIndex)}
-          onExit={() => closePresentation(presentationState.session)}
+          includeOpenCommunitySlot={presentationState.meetup.id === nextMeetup?.id}
+          onNavigate={(slideIndex) => openPresentation(presentationState.meetup, slideIndex)}
+          onExit={() => closePresentation(presentationState.meetup)}
         />
       ) : null}
     </>

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -1,6 +1,5 @@
 export const TRACK_CATEGORY = {
   "Local Builds & Projects": "local-builds",
-  SHIPPED: "shipped",
   "Agent Infrastructure": "agent-infra",
   "Models & Research": "models",
   Security: "security",

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -24,7 +24,7 @@ export function getSlideTrackRouteSlug(slide) {
 }
 
 export function getSlideRouteSlug(slide) {
-  if (slide.type === "session-intro") {
+  if (slide.type === "meetup-intro") {
     return "intro";
   }
 
@@ -43,8 +43,8 @@ export function getSlideRouteSlug(slide) {
   return slugify(slide.item.title);
 }
 
-export function buildSlideHash(session, slide) {
-  return `#/slides/${session.slug}/${getSlideTrackRouteSlug(slide)}/${getSlideRouteSlug(slide)}`;
+export function buildSlideHash(meetup, slide) {
+  return `#/slides/${meetup.slug}/${getSlideTrackRouteSlug(slide)}/${getSlideRouteSlug(slide)}`;
 }
 
 export function parseSlideHash(hash) {
@@ -55,10 +55,10 @@ export function parseSlideHash(hash) {
     return null;
   }
 
-  const [, sessionSlug, trackSlug, slideSlug] = parts;
+  const [, meetupSlug, trackSlug, slideSlug] = parts;
 
   return {
-    sessionSlug: decodeURIComponent(sessionSlug),
+    meetupSlug: decodeURIComponent(meetupSlug),
     trackSlug: decodeURIComponent(trackSlug),
     slideSlug: decodeURIComponent(slideSlug),
   };

--- a/src/data.js
+++ b/src/data.js
@@ -1,7 +1,7 @@
 // This file is the frontend's explicit content contract.
-// Keep it boring: sessions -> tracks -> items.
+// Keep it boring: meetups -> tracks -> items.
 //
-// Optional session-level slideshow shape:
+// Optional meetup-level Presentation Mode shape:
 // - presentationIntro: welcome slide shown before all track slides
 // - event: meetup metadata for reminders + add-to-calendar links
 // - showcases: short end-of-meetup shares rendered as the final track
@@ -11,21 +11,20 @@
 // - embed / embeds: X/Twitter embed override(s)
 // - image / images: linked hero image override(s)
 // - video / videos: standalone video embed override(s)
-// - mediaPair: combined story, usually "video + reaction post"
+// - mediaPair: combined topic, usually "video + reaction post"
 // - linkPair: side-by-side links, useful for repo + dashboard style items
 // - notes: optional presenter note (string) shown as a callout
 // - suppressXEmbeds / suppressVideos / suppressImages: opt out of default media rendering
 //
-// Standard track taxonomy for recurring club sessions:
+// Standard track taxonomy for recurring club meetups:
 // 1. Local Builds & Projects
-// 2. SHIPPED
-// 3. Agent Infrastructure
-// 4. Models & Research
-// 5. Security
-// 6. Big Tech Moves
-export const sessions = [
+// 2. Agent Infrastructure
+// 3. Models & Research
+// 4. Security
+// 5. Big Tech Moves
+export const meetups = [
   {
-    id: "session-2026-04-15",
+    id: "meetup-2026-04-15",
     slug: "2026-04-15",
     date: "April 15, 2026",
     markdownHref: "./topics/2026-04-15.md",
@@ -383,7 +382,7 @@ export const sessions = [
     ],
   },
   {
-    id: "session-2026-04-01",
+    id: "meetup-2026-04-01",
     slug: "2026-04-01",
     date: "April 1, 2026",
     markdownHref: "./topics/2026-04-01.md",
@@ -424,15 +423,6 @@ export const sessions = [
       },
     ],
     tracks: [
-      {
-        id: "apr-shipped",
-        title: "SHIPPED",
-        purpose:
-          "Too many vibe coders burn tokens and ship nothing. What did you actually get into the world this month?",
-        sectionNote:
-          "If you're doing a showcase later, no need to spoil it here — save the good stuff.",
-        items: [],
-      },
       {
         id: "apr-agent-infrastructure",
         title: "Agent Infrastructure",
@@ -1082,7 +1072,7 @@ export const sessions = [
     ],
   },
   {
-    id: "session-2026-03-18",
+    id: "meetup-2026-03-18",
     slug: "2026-03-18",
     date: "March 18, 2026",
     markdownHref: "./topics/2026-03-18.md",

--- a/src/features/archive/ArchiveView.jsx
+++ b/src/features/archive/ArchiveView.jsx
@@ -4,40 +4,42 @@ import {
   formatEventDate,
   formatEventTime,
   getLocationLabel,
-  isUpcomingSession,
+  isUpcomingMeetup,
 } from "../../lib/meetup-ui.js";
 import ArchiveShell from "./ArchiveShell.jsx";
-import { getSessionCounts } from "./sessionSections.jsx";
+import { getMeetupCounts } from "./meetupSections.jsx";
 
-function MeetupCard({ session, onOpenRoute }) {
-  const isUpcoming = isUpcomingSession(session);
-  const { totalTopicCount, totalTrackCount } = getSessionCounts(session);
+function MeetupCard({ meetup, nextMeetupId, onOpenRoute }) {
+  const isUpcoming = isUpcomingMeetup(meetup);
+  const { totalTopicCount, totalTrackCount } = getMeetupCounts(meetup, {
+    acceptsSubmissions: meetup.id === nextMeetupId,
+  });
 
   return (
-    <article className={`session meetup-card ${isUpcoming ? "session--upcoming" : "session--past"}`}>
+    <article className={`meetup meetup-card ${isUpcoming ? "meetup--upcoming" : "meetup--past"}`}>
       <RouteLink
-        to={buildMeetupPath(session.slug)}
+        to={buildMeetupPath(meetup.slug)}
         onOpenRoute={onOpenRoute}
         className="meetup-card-link"
       >
-        <div className="session-header meetup-card-header">
+        <div className="meetup-header meetup-card-header">
           <div className="meetup-card-heading">
             <div>
               <p className="eyebrow meetup-card-eyebrow">
                 {isUpcoming ? "Upcoming meetup" : "Past meetup"}
               </p>
-              <h2>{session.date}</h2>
+              <h2>{meetup.date}</h2>
             </div>
             <span className="meetup-card-open">open meetup</span>
           </div>
-          <p className="session-meta meetup-card-meta">
+          <p className="meetup-meta meetup-card-meta">
             {totalTopicCount} topics &middot; {totalTrackCount} tracks
           </p>
-          {session.event ? (
-            <div className="session-event-meta meetup-card-event">
-              <span>{formatEventDate(session.event)}</span>
-              <span>{formatEventTime(session.event)}</span>
-              <span>{getLocationLabel(session.event)}</span>
+          {meetup.event ? (
+            <div className="meetup-event-meta meetup-card-event">
+              <span>{formatEventDate(meetup.event)}</span>
+              <span>{formatEventTime(meetup.event)}</span>
+              <span>{getLocationLabel(meetup.event)}</span>
             </div>
           ) : null}
         </div>
@@ -46,23 +48,33 @@ function MeetupCard({ session, onOpenRoute }) {
   );
 }
 
-export default function ArchiveView({ sessions, onOpenRoute }) {
-  const upcomingSessions = sessions.filter(isUpcomingSession);
-  const pastSessions = sessions.filter((session) => !isUpcomingSession(session));
+export default function ArchiveView({ meetups, nextMeetupId, onOpenRoute }) {
+  const upcomingMeetups = meetups.filter(isUpcomingMeetup);
+  const pastMeetups = meetups.filter((meetup) => !isUpcomingMeetup(meetup));
 
   return (
     <ArchiveShell onOpenRoute={onOpenRoute}>
       <main className="archive archive--index">
-        {upcomingSessions.map((session) => (
-          <MeetupCard key={session.id} session={session} onOpenRoute={onOpenRoute} />
+        {upcomingMeetups.map((meetup) => (
+          <MeetupCard
+            key={meetup.id}
+            meetup={meetup}
+            nextMeetupId={nextMeetupId}
+            onOpenRoute={onOpenRoute}
+          />
         ))}
-        {upcomingSessions.length > 0 && pastSessions.length > 0 ? (
-          <div className="session-divider" aria-hidden="true">
+        {upcomingMeetups.length > 0 && pastMeetups.length > 0 ? (
+          <div className="meetup-divider" aria-hidden="true">
             <span>Past meetups</span>
           </div>
         ) : null}
-        {pastSessions.map((session) => (
-          <MeetupCard key={session.id} session={session} onOpenRoute={onOpenRoute} />
+        {pastMeetups.map((meetup) => (
+          <MeetupCard
+            key={meetup.id}
+            meetup={meetup}
+            nextMeetupId={nextMeetupId}
+            onOpenRoute={onOpenRoute}
+          />
         ))}
       </main>
     </ArchiveShell>

--- a/src/features/archive/MeetupDetailView.jsx
+++ b/src/features/archive/MeetupDetailView.jsx
@@ -1,26 +1,29 @@
 import { COMMUNITY_SLOT_LABEL, TRACK_CATEGORY } from "../../app/constants.js";
 import RouteLink from "../../components/RouteLink.jsx";
-import { isUpcomingSession } from "../../lib/meetup-ui.js";
+import { isUpcomingMeetup } from "../../lib/meetup-ui.js";
 import ArchiveShell from "./ArchiveShell.jsx";
 import {
-  getSessionCounts,
+  getMeetupCounts,
   getShowcaseId,
-  SessionEventBar,
+  MeetupEventBar,
+  shouldShowCommunitySlot,
   StaticShowcaseSection,
   StaticTrackSection,
-} from "./sessionSections.jsx";
+} from "./meetupSections.jsx";
 
-function TrackJumpNav({ session }) {
+function TrackJumpNav({ meetup, showCommunitySlot }) {
   return (
-    <nav className="track-nav" aria-label={`${session.date} tracks`}>
-      {session.tracks.map((track) => (
+    <nav className="track-nav" aria-label={`${meetup.date} tracks`}>
+      {meetup.tracks.map((track) => (
         <a key={track.id} href={`#${track.id}`} data-track={TRACK_CATEGORY[track.title]}>
           {track.title.toLowerCase()}
         </a>
       ))}
-      <a href={`#${getShowcaseId(session.id)}`} data-track="community">
-        {COMMUNITY_SLOT_LABEL.toLowerCase()}
-      </a>
+      {showCommunitySlot ? (
+        <a href={`#${getShowcaseId(meetup.id)}`} data-track="community">
+          {COMMUNITY_SLOT_LABEL.toLowerCase()}
+        </a>
+      ) : null}
     </nav>
   );
 }
@@ -29,12 +32,12 @@ function MeetupNotFound({ meetupSlug, onOpenRoute }) {
   return (
     <ArchiveShell onOpenRoute={onOpenRoute}>
       <main className="archive archive--detail">
-        <section className="session meetup-state">
-          <div className="session-header meetup-detail-header meetup-state-header">
+        <section className="meetup meetup-state">
+          <div className="meetup-header meetup-detail-header meetup-state-header">
             <p className="eyebrow">Meetup not found</p>
             <h2>{meetupSlug}</h2>
             <p className="submission-blurb">
-              That meetup slug does not match any published session in this archive.
+              That meetup slug does not match any published meetup in this archive.
             </p>
             <RouteLink to="/" onOpenRoute={onOpenRoute} className="calendar-close-btn meetup-back-link">
               back to all meetups
@@ -47,25 +50,29 @@ function MeetupNotFound({ meetupSlug, onOpenRoute }) {
 }
 
 export default function MeetupDetailView({
-  session,
+  meetup,
   meetupSlug,
   nextMeetupId,
   onOpenRoute,
   onOpenPresentation,
   onOpenTopicPresentation,
 }) {
-  if (!session) {
+  if (!meetup) {
     return <MeetupNotFound meetupSlug={meetupSlug} onOpenRoute={onOpenRoute} />;
   }
 
-  const isUpcoming = isUpcomingSession(session);
-  const { totalTopicCount, totalTrackCount } = getSessionCounts(session);
+  const isUpcoming = isUpcomingMeetup(meetup);
+  const acceptsShowcaseSubmissions = meetup.id === nextMeetupId;
+  const showCommunitySlot = shouldShowCommunitySlot(meetup, acceptsShowcaseSubmissions);
+  const { totalTopicCount, totalTrackCount } = getMeetupCounts(meetup, {
+    acceptsSubmissions: acceptsShowcaseSubmissions,
+  });
 
   return (
     <ArchiveShell onOpenRoute={onOpenRoute}>
       <main className="archive archive--detail">
-        <article className={`session session--detail ${isUpcoming ? "session--upcoming" : "session--past"}`}>
-          <div className="session-header meetup-detail-header">
+        <article className={`meetup meetup--detail ${isUpcoming ? "meetup--upcoming" : "meetup--past"}`}>
+          <div className="meetup-header meetup-detail-header">
             <div className="meetup-detail-toolbar">
               <RouteLink
                 to="/"
@@ -74,25 +81,25 @@ export default function MeetupDetailView({
               >
                 back to all meetups
               </RouteLink>
-              <button className="pres-enter-btn" onClick={() => onOpenPresentation(session)}>
-                ▶ slideshow mode
+              <button className="pres-enter-btn" onClick={() => onOpenPresentation(meetup)}>
+                ▶ Presentation Mode
               </button>
             </div>
             <div className="meetup-detail-heading">
               <div>
                 <p className="eyebrow">{isUpcoming ? "Upcoming meetup" : "Meetup archive"}</p>
-                <h2>{session.date}</h2>
-                <p className="session-meta">
+                <h2>{meetup.date}</h2>
+                <p className="meetup-meta">
                   {totalTopicCount} topics &middot; {totalTrackCount} tracks
                 </p>
               </div>
             </div>
-            <TrackJumpNav session={session} />
+            <TrackJumpNav meetup={meetup} showCommunitySlot={showCommunitySlot} />
           </div>
 
-          <div className="session-body session-body--detail">
-            <SessionEventBar session={session} />
-            {session.tracks.map((track, index) => (
+          <div className="meetup-body meetup-body--detail">
+            <MeetupEventBar meetup={meetup} />
+            {meetup.tracks.map((track, index) => (
               <StaticTrackSection
                 key={track.id}
                 track={track}
@@ -100,14 +107,16 @@ export default function MeetupDetailView({
                 onOpenTopic={onOpenTopicPresentation}
               />
             ))}
-            <StaticShowcaseSection
-              index={session.tracks.length}
-              sessionId={session.id}
-              items={session.showcases}
-              acceptsSubmissions={session.id === nextMeetupId}
-              onOpenRoute={onOpenRoute}
-              onOpenTopic={onOpenTopicPresentation}
-            />
+            {showCommunitySlot ? (
+              <StaticShowcaseSection
+                index={meetup.tracks.length}
+                meetupId={meetup.id}
+                items={meetup.showcases}
+                acceptsSubmissions={acceptsShowcaseSubmissions}
+                onOpenRoute={onOpenRoute}
+                onOpenTopic={onOpenTopicPresentation}
+              />
+            ) : null}
           </div>
         </article>
       </main>

--- a/src/features/archive/meetupSections.jsx
+++ b/src/features/archive/meetupSections.jsx
@@ -15,45 +15,51 @@ import {
 } from "../../lib/meetup-ui.js";
 import { Topic } from "../presentation/content.jsx";
 
-export function getSessionCounts(session) {
-  const topicCount = session.tracks.reduce((sum, track) => sum + track.items.length, 0);
-  const showcaseCount = session.showcases?.length ?? 0;
+export function shouldShowCommunitySlot(meetup, acceptsSubmissions = false) {
+  return Boolean((meetup.showcases?.length ?? 0) || acceptsSubmissions);
+}
+
+export function getMeetupCounts(meetup, options = {}) {
+  const { acceptsSubmissions = false } = options;
+  const topicCount = meetup.tracks.reduce((sum, track) => sum + track.items.length, 0);
+  const showcaseCount = meetup.showcases?.length ?? 0;
+  const communitySlotCount = shouldShowCommunitySlot(meetup, acceptsSubmissions) ? 1 : 0;
 
   return {
     topicCount,
     showcaseCount,
     totalTopicCount: topicCount + showcaseCount,
-    totalTrackCount: session.tracks.length + 1,
+    totalTrackCount: meetup.tracks.length + communitySlotCount,
   };
 }
 
-export function getShowcaseId(sessionId) {
-  return `showcase-${sessionId}`;
+export function getShowcaseId(meetupId) {
+  return `showcase-${meetupId}`;
 }
 
 export function getTopicId(sectionId, item, itemIndex) {
   return `${sectionId}-${slugify(item.title)}-${itemIndex}`;
 }
 
-export function SessionEventBar({ session }) {
-  if (!session.event) {
+export function MeetupEventBar({ meetup }) {
+  if (!meetup.event) {
     return null;
   }
 
-  const event = session.event;
+  const event = meetup.event;
 
   return (
-    <div className="session-event">
-      <div className="session-event-meta">
+    <div className="meetup-event">
+      <div className="meetup-event-meta">
         <span>{formatEventDate(event)}</span>
         <span>{formatEventTime(event)}</span>
         <span>{getLocationLabel(event)}</span>
       </div>
-      <div className="session-event-actions">
-        <a href={buildGoogleCalendarUrl(session)} target="_blank" rel="noreferrer">
+      <div className="meetup-event-actions">
+        <a href={buildGoogleCalendarUrl(meetup)} target="_blank" rel="noreferrer">
           add to Google Calendar
         </a>
-        <a href={buildIcsHref(session)}>download ICS</a>
+        <a href={buildIcsHref(meetup)}>download ICS</a>
       </div>
     </div>
   );
@@ -90,13 +96,13 @@ export function StaticTrackSection({ track, index, onOpenTopic }) {
 
 export function StaticShowcaseSection({
   index,
-  sessionId,
+  meetupId,
   items = [],
   acceptsSubmissions,
   onOpenRoute,
   onOpenTopic,
 }) {
-  const showcaseSectionId = getShowcaseId(sessionId);
+  const showcaseSectionId = getShowcaseId(meetupId);
 
   return (
     <section className="track track--static" id={showcaseSectionId} data-track="community">

--- a/src/features/calendar/CalendarView.jsx
+++ b/src/features/calendar/CalendarView.jsx
@@ -44,7 +44,7 @@ function CalendarEventCard({ entry, onOpenRoute }) {
   );
 }
 
-export default function CalendarView({ calendarEntries, nextSession, onClose, onOpenRoute }) {
+export default function CalendarView({ calendarEntries, nextMeetup, onClose, onOpenRoute }) {
   return (
     <section className="calendar-screen" aria-label="Calendar view">
       <header className="calendar-screen-header">
@@ -52,7 +52,7 @@ export default function CalendarView({ calendarEntries, nextSession, onClose, on
           <p className="calendar-eyebrow">Calendar</p>
           <h2>Austin AI Club every two weeks</h2>
           <p className="calendar-blurb">
-            The next four meetup slots stay visible here by default, and hand-authored sessions
+            The next four meetup slots stay visible here by default, and hand-authored meetups
             can replace placeholders as you lock them in.
           </p>
         </div>
@@ -62,7 +62,7 @@ export default function CalendarView({ calendarEntries, nextSession, onClose, on
       </header>
 
       <main className="calendar-screen-body">
-        <ReminderSignup nextSession={nextSession} variant="screen" />
+        <ReminderSignup nextMeetup={nextMeetup} variant="screen" />
         <div className="calendar-list">
           {calendarEntries.map((entry) => (
             <CalendarEventCard

--- a/src/features/calendar/ReminderSignup.jsx
+++ b/src/features/calendar/ReminderSignup.jsx
@@ -9,14 +9,14 @@ import {
   isValidEmail,
 } from "../../lib/meetup-ui.js";
 
-export default function ReminderSignup({ nextSession, variant = "default" }) {
+export default function ReminderSignup({ nextMeetup, variant = "default" }) {
   const submitRef = useRef(false);
   const fallbackTimerRef = useRef(null);
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState("idle");
   const pageUrl = window.location.href;
 
-  const nextEvent = nextSession?.event ?? null;
+  const nextEvent = nextMeetup?.event ?? null;
   const nextLabel = nextEvent
     ? `${formatEventDate(nextEvent)} · ${formatEventTime(nextEvent)}`
     : "We will email you when the next meetup is posted.";

--- a/src/features/calendar/calendar.js
+++ b/src/features/calendar/calendar.js
@@ -3,16 +3,18 @@ import { buildMeetupPath } from "../../app/routes.js";
 import {
   addDays,
   formatDateKey,
+  formatEventDate,
 } from "../../lib/meetup-ui.js";
-import { nextMeetupFromSessions } from "../../meetups.js";
+import { nextMeetupFromMeetups } from "../../meetups.js";
 
-function createCalendarEntry(session) {
+function createCalendarEntry(meetup) {
   return {
-    id: session.id,
+    id: meetup.id,
     kind: "authored",
-    slug: session.slug,
-    detailsHref: buildMeetupPath(session.slug),
-    event: session.event,
+    slug: meetup.slug,
+    date: meetup.date,
+    detailsHref: buildMeetupPath(meetup.slug),
+    event: meetup.event,
   };
 }
 
@@ -25,6 +27,7 @@ function createGeneratedEntry(templateEvent, startAt, index) {
     id: `generated-${dateKey}`,
     kind: "generated",
     slug: dateKey,
+    date: formatEventDate({ ...templateEvent, startAt: startAt.toISOString() }),
     detailsHref: null,
     event: {
       ...templateEvent,
@@ -37,19 +40,19 @@ function createGeneratedEntry(templateEvent, startAt, index) {
   };
 }
 
-export function buildCalendarEntries(sessionList, count = DEFAULT_CALENDAR_EVENT_COUNT) {
-  const authoredSessions = sessionList
-    .filter((session) => session.event)
+export function buildCalendarEntries(meetupList, count = DEFAULT_CALENDAR_EVENT_COUNT) {
+  const authoredMeetups = meetupList
+    .filter((meetup) => meetup.event)
     .sort((a, b) => new Date(a.event.startAt).getTime() - new Date(b.event.startAt).getTime());
 
-  if (!authoredSessions.length) {
+  if (!authoredMeetups.length) {
     return [];
   }
 
-  const anchorEvent = authoredSessions[0].event;
+  const anchorEvent = authoredMeetups[0].event;
   const timeZone = anchorEvent.timezone ?? "America/Chicago";
   const authoredByDate = new Map(
-    authoredSessions.map((session) => [formatDateKey(session.event.startAt, timeZone), createCalendarEntry(session)]),
+    authoredMeetups.map((meetup) => [formatDateKey(meetup.event.startAt, timeZone), createCalendarEntry(meetup)]),
   );
 
   let cursor = new Date(anchorEvent.startAt);
@@ -67,6 +70,18 @@ export function buildCalendarEntries(sessionList, count = DEFAULT_CALENDAR_EVENT
   return entries;
 }
 
-export function getNextSubmissionMeetup(sessionList) {
-  return nextMeetupFromSessions(sessionList);
+export function getNextSubmissionTarget(meetupList) {
+  const nextMeetup = nextMeetupFromMeetups(meetupList);
+  if (nextMeetup) {
+    return {
+      id: nextMeetup.id,
+      kind: "authored",
+      slug: nextMeetup.slug,
+      date: nextMeetup.date,
+      event: nextMeetup.event,
+      detailsHref: buildMeetupPath(nextMeetup.slug),
+    };
+  }
+
+  return buildCalendarEntries(meetupList, 1)[0] ?? null;
 }

--- a/src/features/presentation/PresentationMode.jsx
+++ b/src/features/presentation/PresentationMode.jsx
@@ -1,62 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { COMMUNITY_SLOT_LABEL, TRACK_CATEGORY } from "../../app/constants.js";
 import { buildSlides } from "./slides.js";
-import { TopicMedia, LinkCard } from "./content.jsx";
+import { TopicMedia } from "./content.jsx";
 
-function ShippedLinkInput({ onAdd }) {
-  const [value, setValue] = useState("");
-  const inputRef = useRef(null);
-
-  const submit = () => {
-    const raw = value.trim();
-    if (!raw) return;
-    const href = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-    onAdd(href);
-    setValue("");
-    inputRef.current?.focus();
-  };
-
-  const handleKeyDown = (e) => {
-    e.stopPropagation();
-    if (e.key === "Enter") {
-      e.preventDefault();
-      submit();
-    }
-  };
-
-  return (
-    <form
-      className="shipped-link-form"
-      onSubmit={(e) => { e.preventDefault(); submit(); }}
-    >
-      <input
-        ref={inputRef}
-        className="shipped-link-input"
-        type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder="paste a link — e.g. myapp.com"
-        autoComplete="off"
-        spellCheck={false}
-      />
-      <button className="shipped-link-btn" type="submit" disabled={!value.trim()}>
-        Add
-      </button>
-    </form>
-  );
-}
-
-function PresentationSlide({ slide, isFinale, shippedLinks, onAddShippedLink, onRemoveShippedLink }) {
-  const trackSlug = slide.type === "session-intro"
+function PresentationSlide({ slide, isFinale }) {
+  const trackSlug = slide.type === "meetup-intro"
     ? "local-builds"
     : slide.type.startsWith("community")
       ? "community"
       : TRACK_CATEGORY[slide.track.title];
 
-  if (slide.type === "session-intro") {
+  if (slide.type === "meetup-intro") {
     return (
-      <div className="pres-slide pres-slide--session-intro" data-track={trackSlug}>
+      <div className="pres-slide pres-slide--meetup-intro" data-track={trackSlug}>
         <span className="pres-intro-eyebrow">{slide.intro.eyebrow}</span>
         <h2 className="pres-intro-title">{slide.intro.title}</h2>
         {slide.intro.blurb ? <p className="pres-intro-blurb">{slide.intro.blurb}</p> : null}
@@ -76,8 +32,6 @@ function PresentationSlide({ slide, isFinale, shippedLinks, onAddShippedLink, on
   }
 
   if (slide.type === "track-title") {
-    const isShipped = trackSlug === "shipped";
-
     return (
       <div className="pres-slide pres-slide--track" data-track={trackSlug}>
         <span className="pres-track-num">
@@ -86,31 +40,9 @@ function PresentationSlide({ slide, isFinale, shippedLinks, onAddShippedLink, on
         <h2 className="pres-track-title">{slide.track.title}</h2>
         {slide.track.purpose ? <p className="pres-track-purpose">{slide.track.purpose}</p> : null}
         {slide.track.sectionNote ? <p className="pres-notes">{slide.track.sectionNote}</p> : null}
-        {isShipped ? (
-          <>
-            <ShippedLinkInput onAdd={onAddShippedLink} />
-            {shippedLinks?.length ? (
-              <div className="shipped-link-list">
-                {shippedLinks.map((href, i) => (
-                  <div key={`${href}-${i}`} className="shipped-link-item">
-                    <LinkCard href={href} />
-                    <button
-                      className="shipped-link-remove"
-                      onClick={() => onRemoveShippedLink(i)}
-                      aria-label="Remove link"
-                    >
-                      &times;
-                    </button>
-                  </div>
-                ))}
-              </div>
-            ) : null}
-          </>
-        ) : (
-          <span className="pres-topic-badge">
-            {slide.track.items.length} topic{slide.track.items.length !== 1 ? "s" : ""}
-          </span>
-        )}
+        <span className="pres-topic-badge">
+          {slide.track.items.length} topic{slide.track.items.length !== 1 ? "s" : ""}
+        </span>
       </div>
     );
   }
@@ -199,11 +131,19 @@ function PresentationProgress({ currentIndex, totalSlides, breadcrumb, slideLabe
   );
 }
 
-export default function PresentationMode({ session, currentIndex, onNavigate, onExit }) {
-  const slides = useMemo(() => buildSlides(session), [session]);
+export default function PresentationMode({
+  meetup,
+  currentIndex,
+  includeOpenCommunitySlot = false,
+  onNavigate,
+  onExit,
+}) {
+  const slides = useMemo(
+    () => buildSlides(meetup, { includeOpenCommunitySlot }),
+    [includeOpenCommunitySlot, meetup],
+  );
   const visitedRef = useRef(new Set());
   const touchStartRef = useRef(null);
-  const [shippedLinks, setShippedLinks] = useState([]);
   const slide = slides[currentIndex];
 
   if (!slide) {
@@ -293,28 +233,28 @@ export default function PresentationMode({ session, currentIndex, onNavigate, on
   }, []);
 
   const breadcrumb = slide.type === "topic"
-    ? `${session.date} › ${slide.track.title} › Topic ${slide.itemIndex + 1} of ${slide.itemTotal}`
-    : slide.type === "session-intro"
-      ? `${session.date} › Welcome`
+    ? `${meetup.date} › ${slide.track.title} › Topic ${slide.itemIndex + 1} of ${slide.itemTotal}`
+    : slide.type === "meetup-intro"
+      ? `${meetup.date} › Welcome`
       : slide.type === "community-title"
-        ? `${session.date} › ${COMMUNITY_SLOT_LABEL}`
+        ? `${meetup.date} › ${COMMUNITY_SLOT_LABEL}`
         : slide.type === "community-topic"
-          ? `${session.date} › ${COMMUNITY_SLOT_LABEL} › ${slide.itemIndex + 1} of ${slide.itemTotal}`
-          : `${session.date} › ${slide.track.title}`;
+          ? `${meetup.date} › ${COMMUNITY_SLOT_LABEL} › ${slide.itemIndex + 1} of ${slide.itemTotal}`
+          : `${meetup.date} › ${slide.track.title}`;
 
-  const slideLabel = slide.type === "session-intro"
+  const slideLabel = slide.type === "meetup-intro"
     ? "Welcome"
     : slide.type === "topic"
       ? `Topic ${slide.itemIndex + 1} of ${slide.itemTotal}`
       : slide.type === "community-topic"
         ? `${COMMUNITY_SLOT_LABEL} ${slide.itemIndex + 1} of ${slide.itemTotal}`
         : slide.type === "community-title"
-          ? `Track ${session.tracks.length + 1} of ${session.tracks.length + 1}`
+          ? `Track ${meetup.tracks.length + 1} of ${meetup.tracks.length + 1}`
           : slide.type === "track-outro"
             ? "Discussion prompt"
             : `Track ${slide.trackIndex + 1} of ${slide.trackTotal}`;
 
-  const trackSlug = slide.type === "session-intro"
+  const trackSlug = slide.type === "meetup-intro"
     ? "local-builds"
     : slide.type === "community-title" || slide.type === "community-topic"
       ? "community"
@@ -343,9 +283,6 @@ export default function PresentationMode({ session, currentIndex, onNavigate, on
           <PresentationSlide
             slide={slide}
             isFinale={isFinale}
-            shippedLinks={shippedLinks}
-            onAddShippedLink={(href) => setShippedLinks((prev) => [...prev, href])}
-            onRemoveShippedLink={(index) => setShippedLinks((prev) => prev.filter((_, i) => i !== index))}
           />
         </div>
 

--- a/src/features/presentation/slides.js
+++ b/src/features/presentation/slides.js
@@ -5,23 +5,26 @@ import {
   parseSlideHash,
 } from "../../app/routes.js";
 
-export function buildSlides(session) {
+export function buildSlides(meetup, options = {}) {
+  const { includeOpenCommunitySlot = false } = options;
   const slides = [];
-  const showcases = session.showcases ?? [];
+  const showcases = meetup.showcases ?? [];
+  const includeCommunitySlot = Boolean(showcases.length || includeOpenCommunitySlot);
+  const trackTotal = meetup.tracks.length + (includeCommunitySlot ? 1 : 0);
 
-  if (session.presentationIntro) {
+  if (meetup.presentationIntro) {
     slides.push({
-      type: "session-intro",
-      intro: session.presentationIntro,
+      type: "meetup-intro",
+      intro: meetup.presentationIntro,
     });
   }
 
-  session.tracks.forEach((track, trackIndex) => {
+  meetup.tracks.forEach((track, trackIndex) => {
     slides.push({
       type: "track-title",
       track,
       trackIndex,
-      trackTotal: session.tracks.length,
+      trackTotal,
     });
 
     track.items.forEach((item, itemIndex) => {
@@ -29,7 +32,7 @@ export function buildSlides(session) {
         type: "topic",
         track,
         trackIndex,
-        trackTotal: session.tracks.length,
+        trackTotal,
         item,
         itemIndex,
         itemTotal: track.items.length,
@@ -42,17 +45,21 @@ export function buildSlides(session) {
         type: "track-outro",
         track,
         trackIndex,
-        trackTotal: session.tracks.length,
+        trackTotal,
         outro: track.outro,
       });
     }
   });
 
+  if (!includeCommunitySlot) {
+    return slides;
+  }
+
   slides.push({
     type: "community-title",
     itemTotal: showcases.length,
-    trackIndex: session.tracks.length,
-    trackTotal: session.tracks.length + 1,
+    trackIndex: meetup.tracks.length,
+    trackTotal,
   });
 
   if (showcases.length) {
@@ -62,8 +69,8 @@ export function buildSlides(session) {
         item,
         itemIndex,
         itemTotal: showcases.length,
-        trackIndex: session.tracks.length,
-        trackTotal: session.tracks.length + 1,
+        trackIndex: meetup.tracks.length,
+        trackTotal,
         isLastInTrack: itemIndex === showcases.length - 1,
       });
     });
@@ -72,8 +79,8 @@ export function buildSlides(session) {
   return slides;
 }
 
-export function findSlideIndex(session, route) {
-  const slides = buildSlides(session);
+export function findSlideIndex(meetup, route, options = {}) {
+  const slides = buildSlides(meetup, options);
 
   return slides.findIndex(
     (slide) =>
@@ -82,8 +89,8 @@ export function findSlideIndex(session, route) {
   );
 }
 
-export function findTopicSlideIndex(session, item) {
-  const slides = buildSlides(session);
+export function findTopicSlideIndex(meetup, item, options = {}) {
+  const slides = buildSlides(meetup, options);
 
   return slides.findIndex(
     (slide) =>
@@ -92,28 +99,31 @@ export function findTopicSlideIndex(session, item) {
   );
 }
 
-export function resolvePresentationHash(sessionList, hash) {
+export function resolvePresentationHash(meetupList, hash, options = {}) {
+  const { includeOpenCommunitySlotForMeetupId = null } = options;
   const route = parseSlideHash(hash);
 
   if (!route) {
     return null;
   }
 
-  const session = sessionList.find((candidate) => candidate.slug === route.sessionSlug);
-  if (!session) {
+  const meetup = meetupList.find((candidate) => candidate.slug === route.meetupSlug);
+  if (!meetup) {
     return {
       invalidHash: "",
     };
   }
 
-  const slideIndex = findSlideIndex(session, route);
+  const slideIndex = findSlideIndex(meetup, route, {
+    includeOpenCommunitySlot: meetup.id === includeOpenCommunitySlotForMeetupId,
+  });
   if (slideIndex === -1) {
     return {
       invalidHash: "",
     };
   }
 
-  return { session, slideIndex };
+  return { meetup, slideIndex };
 }
 
 export { buildSlideHash };

--- a/src/features/submissions/SubmissionScreen.jsx
+++ b/src/features/submissions/SubmissionScreen.jsx
@@ -12,7 +12,7 @@ function getInitialValues(fields) {
   return Object.fromEntries(fields.map((field) => [field.name, ""]));
 }
 
-export default function SubmissionScreen({ kind, meetup, onBack, onOpenRoute }) {
+export default function SubmissionScreen({ kind, target, onBack, onOpenRoute }) {
   const screen = submissionScreens[kind];
   const [values, setValues] = useState(() => getInitialValues(screen.fields));
   const [website, setWebsite] = useState("");
@@ -31,9 +31,9 @@ export default function SubmissionScreen({ kind, meetup, onBack, onOpenRoute }) 
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    if (!meetup?.slug || !meetup?.event) {
+    if (!target?.slug || !target?.event) {
       setStatus("error");
-      setErrorMessage("No upcoming meetup is configured yet.");
+      setErrorMessage("No upcoming meetup or meetup slot is configured yet.");
       return;
     }
 
@@ -119,7 +119,7 @@ export default function SubmissionScreen({ kind, meetup, onBack, onOpenRoute }) 
               ? "Issue created. It should now be in the repo with the correct label."
               : status === "error"
                 ? errorMessage
-                : getSubmissionIdleMessage(kind, meetup?.date)}
+                : getSubmissionIdleMessage(kind, target)}
           </p>
 
           <div className="submission-form-switch">

--- a/src/features/submissions/api.js
+++ b/src/features/submissions/api.js
@@ -24,12 +24,15 @@ export async function submitIssueSubmission({ kind, values, website, pageUrl }) 
   return payload;
 }
 
-export function getSubmissionIdleMessage(kind, meetupDate) {
+export function getSubmissionIdleMessage(kind, target) {
+  const targetLabel = target?.date ?? target?.event?.title ?? "the next meetup";
+  const targetKind = target?.kind === "generated" ? "meetup slot" : "meetup";
+
   if (kind === "link") {
-    return `This creates a GitHub issue for ${meetupDate ?? "the next meetup"} labeled link.`;
+    return `This creates a GitHub issue for ${targetLabel} ${targetKind} labeled link.`;
   }
 
-  return `This creates a GitHub issue for ${meetupDate ?? "the next meetup"} labeled ${COMMUNITY_SLOT_LABEL.toLowerCase()}.`;
+  return `This creates a GitHub issue for ${targetLabel} ${targetKind} labeled ${COMMUNITY_SLOT_LABEL.toLowerCase()}.`;
 }
 
 export function validateSubmissionInput(kind, values) {

--- a/src/lib/meetup-ui.js
+++ b/src/lib/meetup-ui.js
@@ -13,8 +13,8 @@ export function toGoogleCalendarTimestamp(value) {
   return new Date(value).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
 }
 
-export function buildGoogleCalendarUrl(session) {
-  const event = session.event;
+export function buildGoogleCalendarUrl(meetup) {
+  const event = meetup.event;
 
   if (!event) {
     return "";
@@ -32,8 +32,8 @@ export function buildGoogleCalendarUrl(session) {
   return `https://calendar.google.com/calendar/render?${params.toString()}`;
 }
 
-export function buildIcsHref(session) {
-  return `/calendar/${session.slug}.ics`;
+export function buildIcsHref(meetup) {
+  return `/calendar/${meetup.slug}.ics`;
 }
 
 export function formatEventDate(event) {
@@ -105,12 +105,12 @@ export function createInlineIcsHref(entry) {
   return `data:text/calendar;charset=utf-8,${encodeURIComponent(lines.join("\r\n"))}`;
 }
 
-export function isUpcomingSession(session) {
-  if (!session.event) {
+export function isUpcomingMeetup(meetup) {
+  if (!meetup.event) {
     return false;
   }
 
-  return new Date(session.event.endAt).getTime() >= Date.now();
+  return new Date(meetup.event.endAt).getTime() >= Date.now();
 }
 
 export function isValidEmail(value) {

--- a/src/meetups.js
+++ b/src/meetups.js
@@ -1,5 +1,5 @@
-export function nextMeetupFromSessions(sessionList, now = Date.now()) {
-  return sessionList
-    .filter((session) => session.event && new Date(session.event.endAt).getTime() >= now)
+export function nextMeetupFromMeetups(meetupList, now = Date.now()) {
+  return meetupList
+    .filter((meetup) => meetup.event && new Date(meetup.event.endAt).getTime() >= now)
     .sort((a, b) => new Date(a.event.startAt).getTime() - new Date(b.event.startAt).getTime())[0] ?? null;
 }

--- a/src/styles/archive.css
+++ b/src/styles/archive.css
@@ -1,6 +1,6 @@
-/* Session cards */
+/* Meetup cards */
 
-.session {
+.meetup {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--panel);
@@ -9,15 +9,15 @@
   animation: boot-in 600ms ease both;
 }
 
-.session:nth-child(1) {
+.meetup:nth-child(1) {
   animation-delay: 120ms;
 }
 
-.session:nth-child(2) {
+.meetup:nth-child(2) {
   animation-delay: 220ms;
 }
 
-.session-header {
+.meetup-header {
   padding: 1rem 1.25rem 0.85rem;
   cursor: pointer;
   list-style: none;
@@ -49,13 +49,13 @@
   background: linear-gradient(155deg, rgba(71, 243, 170, 0.08), transparent 46%);
 }
 
-.session-header::-webkit-details-marker,
-.session-header::marker {
+.meetup-header::-webkit-details-marker,
+.meetup-header::marker {
   display: none;
   content: "";
 }
 
-.session-header::before {
+.meetup-header::before {
   content: "";
   position: absolute;
   left: 0;
@@ -66,43 +66,43 @@
   box-shadow: 0 0 14px rgba(71, 243, 170, 0.34);
 }
 
-.session[open] .session-header {
+.meetup[open] .meetup-header {
   border-bottom: 1px solid var(--line);
 }
 
-.session--past {
+.meetup--past {
   border-color: rgba(71, 243, 170, 0.11);
   background: rgba(4, 11, 18, 0.84);
   box-shadow: 0 18px 38px rgba(0, 0, 0, 0.22);
 }
 
-.session--past .session-header {
+.meetup--past .meetup-header {
   background: linear-gradient(155deg, rgba(71, 243, 170, 0.02), transparent 40%);
 }
 
-.session--past .session-header::before {
+.meetup--past .meetup-header::before {
   background: rgba(71, 243, 170, 0.62);
   box-shadow: 0 0 10px rgba(71, 243, 170, 0.18);
 }
 
-.session--past .session-header h2 {
+.meetup--past .meetup-header h2 {
   color: rgba(226, 241, 235, 0.88);
 }
 
-.session--past .session-meta,
-.session--past .track-num {
+.meetup--past .meetup-meta,
+.meetup--past .track-num {
   color: rgba(169, 190, 181, 0.8);
 }
 
-.session--past .chevron::before {
+.meetup--past .chevron::before {
   border-right-color: rgba(71, 243, 170, 0.72);
   border-bottom-color: rgba(71, 243, 170, 0.72);
 }
 
-.session--past .track-nav a,
-.session--past .session-event-meta span,
-.session--past .session-event-actions a,
-.session--past .pres-enter-btn {
+.meetup--past .track-nav a,
+.meetup--past .meetup-event-meta span,
+.meetup--past .meetup-event-actions a,
+.meetup--past .pres-enter-btn {
   opacity: 0.72;
 }
 
@@ -128,11 +128,11 @@
   opacity: 0.75;
 }
 
-.session[open] .chevron::before {
+.meetup[open] .chevron::before {
   transform: translate(-50%, -50%) rotate(45deg);
 }
 
-.session-date {
+.meetup-date {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -143,7 +143,7 @@
   cursor: default;
 }
 
-.session-header h2 {
+.meetup-header h2 {
   margin: 0;
   font-family: var(--font-display);
   font-size: clamp(1.3rem, 2.2vw, 1.75rem);
@@ -211,7 +211,7 @@
   gap: 0.75rem;
 }
 
-.session-meta {
+.meetup-meta {
   margin: 0.15rem 0 0.65rem;
   color: var(--text-sub);
   font-size: 0.76rem;
@@ -234,17 +234,17 @@
 
 /* Tracks + topics */
 
-.session-body {
+.meetup-body {
   padding: 0.75rem;
   display: grid;
   gap: 0.7rem;
 }
 
-.session-body--detail {
+.meetup-body--detail {
   padding-top: 0.85rem;
 }
 
-.session-event {
+.meetup-event {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -253,14 +253,14 @@
   padding: 0.2rem 0.2rem 0.05rem;
 }
 
-.session-event-meta,
-.session-event-actions {
+.meetup-event-meta,
+.meetup-event-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
 }
 
-.session-event-meta span {
+.meetup-event-meta span {
   padding: 0.26rem 0.52rem;
   border: 1px solid var(--line);
   border-radius: 999px;
@@ -270,7 +270,7 @@
   letter-spacing: 0.02em;
 }
 
-.session-event-actions a {
+.meetup-event-actions a {
   min-height: 2.2rem;
   padding: 0 0.85rem;
   font-size: 0.72rem;
@@ -762,7 +762,7 @@
     width: 100%;
   }
 
-  .session-event {
+  .meetup-event {
     align-items: flex-start;
   }
 
@@ -788,11 +788,11 @@
     justify-content: flex-start;
   }
 
-  .session-header {
+  .meetup-header {
     padding: 0.8rem;
   }
 
-  .session-body {
+  .meetup-body {
     padding: 0.5rem;
   }
 
@@ -804,7 +804,7 @@
     padding: 0.55rem;
   }
 
-  .session-index {
+  .meetup-index {
     padding: 0.45rem 0.55rem;
   }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -29,15 +29,6 @@
   --t-bg-radial: rgba(71, 243, 170, 0.1);
 }
 
-[data-track="shipped"] {
-  --t-accent: #f3df47;
-  --t-dim: #c9af2b;
-  --t-soft: rgba(243, 223, 71, 0.06);
-  --t-glow: rgba(243, 223, 71, 0.3);
-  --t-line: rgba(243, 223, 71, 0.18);
-  --t-bg-radial: rgba(243, 223, 71, 0.1);
-}
-
 [data-track="agent-infra"] {
   --t-accent: #47d4f3;
   --t-dim: #2ba8c9;
@@ -211,7 +202,7 @@ summary {
 
 .eyebrow,
 .footer-label,
-.session-meta,
+.meetup-meta,
 .track-nav a,
 .video-caption,
 .source-chip {
@@ -270,4 +261,4 @@ summary {
   border-bottom-color: var(--accent-dim);
 }
 
-/* Session index */
+/* Meetup index */

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,4 +1,4 @@
-.session-index {
+.meetup-index {
   display: flex;
   gap: 0.4rem;
   align-items: center;
@@ -30,7 +30,7 @@
   gap: 1rem;
 }
 
-.session-divider {
+.meetup-divider {
   display: flex;
   align-items: center;
   gap: 0.8rem;
@@ -41,19 +41,19 @@
   text-transform: uppercase;
 }
 
-.session-divider::before,
-.session-divider::after {
+.meetup-divider::before,
+.meetup-divider::after {
   content: "";
   height: 1px;
   flex: 1;
   background: linear-gradient(90deg, rgba(71, 243, 170, 0.06), rgba(71, 243, 170, 0.3));
 }
 
-.session-divider::after {
+.meetup-divider::after {
   background: linear-gradient(90deg, rgba(71, 243, 170, 0.3), rgba(71, 243, 170, 0.06));
 }
 
-.session-divider span {
+.meetup-divider span {
   padding: 0.3rem 0.7rem;
   border: 1px solid rgba(71, 243, 170, 0.14);
   border-radius: 999px;
@@ -133,14 +133,14 @@
 
 .reminder-form input:focus-visible,
 .reminder-form button:focus-visible,
-.session-event-actions a:focus-visible {
+.meetup-event-actions a:focus-visible {
   outline: none;
   border-color: rgba(71, 243, 170, 0.54);
   box-shadow: 0 0 0 2px rgba(71, 243, 170, 0.2);
 }
 
 .reminder-form button,
-.session-event-actions a {
+.meetup-event-actions a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -167,7 +167,7 @@
 }
 
 .reminder-form button:hover,
-.session-event-actions a:hover {
+.meetup-event-actions a:hover {
   transform: translateY(-1px);
   background: linear-gradient(180deg, rgba(71, 243, 170, 0.22), rgba(71, 243, 170, 0.12));
   border-color: rgba(71, 243, 170, 0.42);

--- a/src/styles/presentation.css
+++ b/src/styles/presentation.css
@@ -140,7 +140,7 @@
   width: 100%;
 }
 
-.pres-slide--session-intro {
+.pres-slide--meetup-intro {
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
@@ -456,7 +456,7 @@
   display: none;
 }
 
-/* Enter button (in session header) */
+/* Enter button (in meetup header) */
 
 .pres-enter-btn {
   display: inline-flex;
@@ -601,117 +601,6 @@
   max-width: 980px;
 }
 
-/* Shipped live-link input */
-
-.shipped-link-form {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  margin-top: 1.1rem;
-  width: 100%;
-  max-width: 480px;
-}
-
-.shipped-link-input {
-  flex: 1;
-  min-height: 2.8rem;
-  padding: 0.6rem 1rem;
-  border: 1px solid var(--t-line, var(--line));
-  border-radius: 999px;
-  background: rgba(5, 14, 22, 0.72);
-  color: var(--text);
-  font-family: var(--font-mono);
-  font-size: 0.88rem;
-  letter-spacing: 0.02em;
-  outline: none;
-  transition: border-color 200ms ease, box-shadow 200ms ease;
-}
-
-.shipped-link-input::placeholder {
-  color: var(--muted);
-  opacity: 0.7;
-}
-
-.shipped-link-input:focus {
-  border-color: var(--t-accent, var(--accent));
-  box-shadow: 0 0 0 2px var(--t-glow, rgba(243, 223, 71, 0.2));
-}
-
-.shipped-link-btn {
-  min-height: 2.8rem;
-  padding: 0.6rem 1.2rem;
-  border: 1px solid var(--t-line, var(--line));
-  border-radius: 999px;
-  background: var(--t-soft, rgba(243, 223, 71, 0.08));
-  color: var(--t-accent, var(--accent));
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  cursor: pointer;
-  transition: background 160ms ease, border-color 160ms ease, opacity 160ms ease;
-}
-
-.shipped-link-btn:hover:not(:disabled) {
-  background: rgba(243, 223, 71, 0.15);
-  border-color: var(--t-accent, var(--accent));
-}
-
-.shipped-link-btn:disabled {
-  opacity: 0.35;
-  cursor: default;
-}
-
-.shipped-link-list {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.85rem;
-  width: 100%;
-  max-width: 520px;
-}
-
-.shipped-link-item {
-  position: relative;
-  width: 100%;
-}
-
-.shipped-link-item .link-card {
-  margin-top: 0;
-}
-
-.shipped-link-remove {
-  position: absolute;
-  top: 0.45rem;
-  right: 0.45rem;
-  width: 1.6rem;
-  height: 1.6rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--t-line, var(--line));
-  border-radius: 50%;
-  background: rgba(5, 14, 22, 0.85);
-  color: var(--muted);
-  font-size: 1rem;
-  line-height: 1;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 160ms ease, color 160ms ease, background 160ms ease;
-}
-
-.shipped-link-item:hover .shipped-link-remove {
-  opacity: 1;
-}
-
-.shipped-link-remove:hover {
-  color: #f37188;
-  background: rgba(243, 113, 136, 0.1);
-  border-color: rgba(243, 113, 136, 0.3);
-}
-
 /* Responsive adjustments for presentation */
 
 @media (max-width: 720px) {
@@ -730,30 +619,6 @@
 }
 
 @media (max-width: 640px) {
-  .shipped-link-form {
-    max-width: 100%;
-  }
-
-  .shipped-link-input {
-    min-height: 2.5rem;
-    padding: 0.5rem 0.85rem;
-    font-size: 0.82rem;
-  }
-
-  .shipped-link-btn {
-    min-height: 2.5rem;
-    padding: 0.5rem 0.9rem;
-    font-size: 0.72rem;
-  }
-
-  .shipped-link-list {
-    max-width: 100%;
-  }
-
-  .shipped-link-remove {
-    opacity: 1;
-  }
-
   .pres-topbar {
     align-items: flex-start;
     padding: 0.7rem 0.85rem;
@@ -795,7 +660,7 @@
     max-width: 100%;
   }
 
-  .pres-slide--session-intro {
+  .pres-slide--meetup-intro {
     gap: 0.75rem;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive domain guide clarifying meetup terminology, relationships, and ambiguity rules.
  * Rewrote README and guides to align with the meetups + Presentation Mode model and updated setup/workflow docs.

* **Content Updates**
  * Removed the "SHIPPED" section from meetup notes; added a "Local Builds & Projects" showcase.
  * Standardized topic/template fields and presentation notes.

* **Improvements**
  * Moved site data and views from session-based to meetup-based models (calendar, archive, presentation, reminders, submissions).
  * Submission targeting and calendar/ICS behavior improved; meetup IDs standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->